### PR TITLE
Fix: `/api/auth/info`

### DIFF
--- a/src/models/users.db.ts
+++ b/src/models/users.db.ts
@@ -42,13 +42,22 @@ export async function findUniqueUserWithRoleData(
         where: { cohortYear: academicYear },
       },
       adviser: { where: { cohortYear: academicYear } },
+      administrator: { where: { endDate: { gte: new Date() } } },
     },
     rejectOnNotFound: false,
   });
   if (!user) {
     throw new SkylabError("User was not found", HttpStatusCode.BAD_REQUEST);
   }
-  return user;
+
+  const { student, mentor, administrator, adviser, ...userInfo } = user;
+  return {
+    ...userInfo,
+    student: student[0] ?? {},
+    mentor: mentor[0] ?? {},
+    adviser: adviser[0] ?? {},
+    administrator: administrator[0] ?? {},
+  };
 }
 
 export async function findManyUsers(query: Prisma.UserFindManyArgs) {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -6,6 +6,7 @@ import {
   sendPasswordResetEmail,
   userLogin,
 } from "src/helpers/authentication.helper";
+import { getOneUserById } from "src/helpers/users.helper";
 import authorize from "src/middleware/jwtAuth";
 import {
   findUniqueUser,
@@ -70,7 +71,11 @@ router.get("/sign-out", authorize, async (_: Request, res: Response) => {
 router.get("/info", authorize, async (req: Request, res: Response) => {
   try {
     const { token } = req.cookies;
-    const userData = jwt.verify(token, process.env.JWT_SECRET ?? "jwt_secret");
+    const jwtData = jwt.verify(
+      token,
+      process.env.JWT_SECRET ?? "jwt_secret"
+    ) as any;
+    const userData = await getOneUserById(Number(jwtData.id));
     return apiResponseWrapper(res, userData as JwtPayload);
   } catch (e) {
     return routeErrorHandler(res, e);


### PR DESCRIPTION
- [x] Instead of returning the data inside the JWT token as the user data (which may be outdated), re-fetch the user data using the user id stored in the JWT token
- [x] Add the administrator role to the `/auth/info` route and unwrap the roles from arrays