### PR TITLE
feat: add public projects API endpoint for SSG

### DIFF
--- a/src/helpers/projects.helper.ts
+++ b/src/helpers/projects.helper.ts
@@ -214,3 +214,20 @@ export async function getAdviserUserByProjectID(projectId: number) {
   });
   return adviser;
 }
+
+/**
+ * Fetch public projects for static site generation
+ * Returns up to 10 non-dropped projects with student, adviser, and mentor data
+ * Ordered by most recent cohort year and project ID
+ */
+export async function getPublicProjects(limit = 10) {
+  const projects = await findManyProjectsWithUserData({
+    where: {
+      hasDropped: false,
+    },
+    take: limit,
+    orderBy: [{ cohortYear: "desc" }, { id: "desc" }],
+  });
+
+  return projects.map((project) => parseGetProjectInput(project));
+}

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -8,6 +8,7 @@ import {
   getManyProjectsWithFilter,
   getOneProjectById,
   getProjectsViaRoleIds,
+  getPublicProjects,
 } from "../helpers/projects.helper";
 import authorizeAdmin from "../middleware/authorizeAdmin";
 import authorizeAdviserOfProject from "../middleware/authorizeAdviserOfProject";
@@ -77,6 +78,15 @@ router.get("/mentor/:mentorId", async (req: Request, res: Response) => {
       mentorId: Number(mentorId),
     });
     return apiResponseWrapper(res, { projects: projects });
+  } catch (e) {
+    return routeErrorHandler(res, e);
+  }
+});
+
+router.get("/public", async (req: Request, res: Response) => {
+  try {
+    const publicProjects = await getPublicProjects(10);
+    return apiResponseWrapper(res, { projects: publicProjects });
   } catch (e) {
     return routeErrorHandler(res, e);
   }


### PR DESCRIPTION
**projects.ts**:
- Added GET /projects/public route
- Returns 10 non-dropped projects with full user data

**projects.helper.ts**:
- Added getPublicProjects(limit = 10) function
- Filters: hasDropped: false
- Orders by: cohortYear DESC, id DESC (most recent first)
- Returns parsed projects with students, adviser, mentor data
