### PR TITLE
feat: add evaluation chart 

### DIFF
--- a/prisma/migrations/20260226171503_add_evaluator_type/migration.sql
+++ b/prisma/migrations/20260226171503_add_evaluator_type/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "EvaluatorType" AS ENUM ('Adviser', 'Team', 'Both');
+
+-- AlterTable
+ALTER TABLE "Deadline" ADD COLUMN     "evaluatorType" "EvaluatorType";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -135,6 +135,7 @@ model Deadline {
   submission            Submission[]
   evaluating            Deadline?            @relation(fields: [evaluatingMilestoneId], references: [id], name: "evaluation")
   evaluatingMilestoneId Int?                 @unique
+  evaluatorType         EvaluatorType?              
   evaluatedBy           Deadline?            @relation(name: "evaluation")
   anonymousApplicants   AnonymousApplicant[]
 
@@ -371,6 +372,12 @@ enum DeadlineType {
   Feedback
   Application
   Other
+}
+
+enum EvaluatorType {
+  Adviser
+  Team
+  Both
 }
 
 enum QuestionType {

--- a/prisma/seed/deadline.seed.ts
+++ b/prisma/seed/deadline.seed.ts
@@ -1,4 +1,9 @@
-import { DeadlineType, QuestionType, type PrismaClient } from "@prisma/client";
+import {
+  DeadlineType,
+  EvaluatorType,
+  QuestionType,
+  type PrismaClient,
+} from "@prisma/client";
 
 export const seedDeadlines = async (prisma: PrismaClient) => {
   const today = new Date();
@@ -17,6 +22,10 @@ export const seedDeadlines = async (prisma: PrismaClient) => {
           name: `${deadlineType} ${i}`,
           type: deadlineType,
           dueBy: nextWeek,
+          evaluatorType:
+            deadlineType === DeadlineType.Evaluation
+              ? EvaluatorType.Both
+              : undefined,
           evaluating:
             deadlineType === DeadlineType.Evaluation
               ? {

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -39,15 +39,15 @@ export type EvaluationResult = {
 
 export function flattenProjectUsers(
   project: Project & {
-    students: (Student & {
+    students?: (Student & {
       user: User;
     })[];
-    mentor:
+    mentor?:
       | (Mentor & {
           user: User;
         })
       | null;
-    adviser:
+    adviser?:
       | (Adviser & {
           user: User;
         })
@@ -55,15 +55,18 @@ export function flattenProjectUsers(
   }
 ) {
   const { students, adviser, mentor, ...projectData } = project;
-  const flattenedStudents = students.map((student) => {
-    const { user, ...studentData } = student;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id, password, ...userData } = user;
-    return {
-      ...userData,
-      ...studentData,
-    };
-  });
+
+  const flattenedStudents = students
+    ? students.map((student) => {
+        const { user, ...studentData } = student;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { id, password, ...userData } = user;
+        return {
+          ...userData,
+          ...studentData,
+        };
+      })
+    : [];
 
   let tempMentorAdviser;
 
@@ -346,6 +349,7 @@ export async function sendReminderEmail(
     throw e;
   }
 }
+
 export const getAllEvaluationSubmissions = async (query: any) => {
   const { search, cohortYear, page, limit, dropped, evaluatorTypeFilter } =
     query;
@@ -413,6 +417,16 @@ export const getAllEvaluationSubmissions = async (query: any) => {
       },
     });
 
+    const evaluatorProjectIds = Array.from(
+      new Set(relations.map((r) => r.fromProjectId))
+    );
+    const evaluatorProjects = await findManyProjectsWithUserData({
+      where: { id: { in: evaluatorProjectIds } },
+    });
+    const projectsWithStudentsMap = new Map(
+      evaluatorProjects.map((p) => [p.id, p.students])
+    );
+
     const pTeamSubmissions = relations.map(async (relation) => {
       const submissions = await findManySubmissions({
         where: {
@@ -422,6 +436,16 @@ export const getAllEvaluationSubmissions = async (query: any) => {
         },
         select: { id: true, updatedAt: true, deadlineId: true },
       });
+
+      const rawStudents =
+        projectsWithStudentsMap.get(relation.fromProjectId) || [];
+      const flattenedStudents = rawStudents.map((student) => {
+        const { user, ...studentData } = student;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { id, password, ...userData } = user || {};
+        return { ...userData, ...studentData };
+      });
+
       return {
         relationId: relation.id,
         fromProject: {
@@ -432,6 +456,7 @@ export const getAllEvaluationSubmissions = async (query: any) => {
                 ...relation.fromProject.adviser.user,
               }
             : null,
+          students: flattenedStudents,
         },
         toProject: flattenProjectUsers(relation.toProject),
         submission: submissions || undefined,
@@ -565,6 +590,16 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
       },
     });
 
+    const evaluatorProjectIds = Array.from(
+      new Set(relations.map((r) => r.fromProjectId))
+    );
+    const evaluatorProjects = await findManyProjectsWithUserData({
+      where: { id: { in: evaluatorProjectIds } },
+    });
+    const projectsWithStudentsMap = new Map(
+      evaluatorProjects.map((p) => [p.id, p.students])
+    );
+
     const pTeamSubmissions = relations.map(async (relation) => {
       const submission = await findFirstNonDraftSubmission({
         where: {
@@ -573,6 +608,16 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
           toProjectId: relation.toProjectId,
         },
       });
+
+      const rawStudents =
+        projectsWithStudentsMap.get(relation.fromProjectId) || [];
+      const flattenedStudents = rawStudents.map((student) => {
+        const { user, ...studentData } = student;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { id, password, ...userData } = user || {};
+        return { ...userData, ...studentData };
+      });
+
       return {
         relationId: relation.id,
         fromProject: {
@@ -583,6 +628,7 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
                 ...relation.fromProject.adviser.user,
               }
             : null,
+          students: flattenedStudents,
         },
         toProject: flattenProjectUsers(relation.toProject),
         submission: submission || undefined,

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -156,7 +156,6 @@ export const getAllSubmissions = async (
     },
     take: query.limit ?? undefined,
     skip: query.limit && query.page ? limit * page : undefined,
-    orderBy: { id: "asc" },
   });
 
   const milestoneDeadlines = await findManyDeadlines({

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -636,7 +636,12 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
         submission: submission || undefined,
       };
     });
-    results.push(...(await Promise.all(pAdviserSubmissions)));
+    const resolvedAdviserSubmissions = await Promise.all(pAdviserSubmissions);
+    results.push(
+      ...resolvedAdviserSubmissions.filter(
+        (res): res is NonNullable<typeof res> => res !== null
+      )
+    );
   }
 
   if (submissionStatus) {

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -9,7 +9,10 @@ import {
 } from "@prisma/client";
 import { findUniqueDeadline, findManyDeadlines } from "../models/deadline.db";
 import { findManyProjectsWithUserData } from "../models/projects.db";
-import { findManyRelationsWithFromToProjectData } from "../models/relations.db";
+import {
+  findManyRelationsWithFromToProjectData,
+  findManyRelationsForEvaluations,
+} from "../models/relations.db";
 import {
   findFirstNonDraftSubmission,
   findManySubmissions,
@@ -21,6 +24,18 @@ export enum SubmissionStatusEnum {
   SUBMITTED = "Submitted",
   SUBMITTED_LATE = "Submitted_Late",
 }
+
+export type FlattenedProject = ReturnType<typeof flattenProjectUsers>;
+
+export type EvaluationResult = {
+  relationId: string | number;
+  fromProject?: FlattenedProject;
+  fromUser?: User;
+  toProject: FlattenedProject;
+  submission?: Submission | Submission[];
+  id?: number;
+  updatedAt?: Date;
+};
 
 export function flattenProjectUsers(
   project: Project & {
@@ -122,27 +137,34 @@ export const getAllSubmissions = async (
   }
 ) => {
   const { search, cohortYear, page, limit, dropped } = query;
+  const isDropped = dropped === "true" || dropped === true;
+
+  const searchCondition = search
+    ? {
+        OR: [
+          { name: { contains: search, mode: "insensitive" as const } },
+          { teamName: { contains: search, mode: "insensitive" as const } },
+        ],
+      }
+    : {};
+
   const projects = await findManyProjectsWithUserData({
     where: {
-      cohortYear: cohortYear,
-      name: search ? { contains: search } : undefined,
+      cohortYear: Number(cohortYear),
+      hasDropped: isDropped,
+      ...searchCondition,
     },
     take: query.limit ?? undefined,
     skip: query.limit && query.page ? limit * page : undefined,
+    orderBy: { id: "asc" },
   });
 
   const milestoneDeadlines = await findManyDeadlines({
     where: {
+      cohortYear: Number(cohortYear),
       type: "Milestone",
     },
   });
-
-  let results: {
-    fromProject: Project;
-    toUser?: User;
-    toProject?: Project;
-    submission?: Submission[];
-  }[];
 
   const pSubmissions = projects.map(async (project) => {
     const submission = await findManySubmissions({
@@ -167,17 +189,7 @@ export const getAllSubmissions = async (
     };
   });
 
-  results = await Promise.all(pSubmissions);
-
-  results = results.filter((result) => {
-    if (dropped == "true") {
-      return !!result.fromProject.hasDropped;
-    } else {
-      return !result.fromProject.hasDropped;
-    }
-  });
-
-  return results;
+  return await Promise.all(pSubmissions);
 };
 
 export const getSubmissionsByDeadlineId = async (
@@ -335,3 +347,331 @@ export async function sendReminderEmail(
     throw e;
   }
 }
+export const getAllEvaluationSubmissions = async (query: any) => {
+  const { search, cohortYear, page, limit, dropped, evaluatorTypeFilter } =
+    query;
+  const isDropped = dropped === "true" || dropped === true;
+
+  const teamSearchCondition = search
+    ? {
+        OR: [
+          {
+            fromProject: {
+              name: { contains: search, mode: "insensitive" as const },
+            },
+          },
+          {
+            fromProject: {
+              teamName: { contains: search, mode: "insensitive" as const },
+            },
+          },
+          {
+            toProject: {
+              name: { contains: search, mode: "insensitive" as const },
+            },
+          },
+          {
+            toProject: {
+              teamName: { contains: search, mode: "insensitive" as const },
+            },
+          },
+        ],
+      }
+    : {};
+  const adviserSearchCondition = search
+    ? {
+        OR: [
+          {
+            adviser: {
+              user: {
+                name: { contains: search, mode: "insensitive" as const },
+              },
+            },
+          },
+          { name: { contains: search, mode: "insensitive" as const } },
+          { teamName: { contains: search, mode: "insensitive" as const } },
+        ],
+      }
+    : {};
+
+  const evaluationDeadlines = await findManyDeadlines({
+    where: { cohortYear: Number(cohortYear), type: "Evaluation" },
+  });
+  const deadlineIds = evaluationDeadlines.map((d) => d.id);
+
+  let combined: any[] = [];
+
+  // Fetch Teams if filter allows
+  if (
+    !evaluatorTypeFilter ||
+    evaluatorTypeFilter === "All" ||
+    evaluatorTypeFilter === "Team"
+  ) {
+    const relations = await findManyRelationsForEvaluations({
+      where: {
+        fromProject: { cohortYear: Number(cohortYear), hasDropped: isDropped },
+        ...teamSearchCondition,
+      },
+    });
+
+    const pTeamSubmissions = relations.map(async (relation) => {
+      const submissions = await findManySubmissions({
+        where: {
+          fromProjectId: relation.fromProjectId,
+          toProjectId: relation.toProjectId,
+          deadlineId: { in: deadlineIds },
+        },
+        select: { id: true, updatedAt: true, deadlineId: true },
+      });
+      return {
+        relationId: relation.id,
+        fromProject: {
+          ...relation.fromProject,
+          adviser: relation.fromProject.adviser
+            ? {
+                ...relation.fromProject.adviser,
+                ...relation.fromProject.adviser.user,
+              }
+            : null,
+        },
+        toProject: flattenProjectUsers(relation.toProject),
+        submission: submissions || undefined,
+      };
+    });
+    combined.push(...(await Promise.all(pTeamSubmissions)));
+  }
+
+  if (
+    !evaluatorTypeFilter ||
+    evaluatorTypeFilter === "All" ||
+    evaluatorTypeFilter === "Adviser"
+  ) {
+    const adviserProjects = await findManyProjectsWithUserData({
+      where: {
+        cohortYear: Number(cohortYear),
+        hasDropped: isDropped,
+        adviserId: { not: null },
+        ...adviserSearchCondition,
+      },
+    });
+
+    const pAdviserSubmissions = adviserProjects.map(async (project) => {
+      const submissions = await findManySubmissions({
+        where: {
+          fromUserId: project.adviser?.userId,
+          toProjectId: project.id,
+          deadlineId: { in: deadlineIds },
+        },
+        select: { id: true, updatedAt: true, deadlineId: true },
+      });
+      return {
+        relationId: `A-${project.id}`,
+        fromUser: project.adviser?.user,
+        toProject: flattenProjectUsers(project),
+        submission: submissions || undefined,
+      };
+    });
+    combined.push(...(await Promise.all(pAdviserSubmissions)));
+  }
+
+  combined.sort((a, b) => {
+    const isANum = typeof a.relationId === "number";
+    const isBNum = typeof b.relationId === "number";
+    if (isANum && isBNum)
+      return (a.relationId as number) - (b.relationId as number);
+    if (!isANum && !isBNum)
+      return String(a.relationId).localeCompare(
+        String(b.relationId),
+        undefined,
+        { numeric: true }
+      );
+    return isANum ? -1 : 1;
+  });
+
+  if (limit !== undefined && page !== undefined) {
+    const startIndex = Number(limit) * Number(page);
+    combined = combined.slice(startIndex, startIndex + Number(limit));
+  }
+
+  return combined;
+};
+
+export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
+  const {
+    submissionStatus,
+    search,
+    cohortYear,
+    page,
+    limit,
+    deadlineId,
+    dropped,
+    evaluatorTypeFilter,
+  } = query;
+  const isDropped = dropped === "true" || dropped === true;
+
+  const deadline = await findUniqueDeadline({
+    where: { id: Number(deadlineId) },
+  });
+
+  let results: any[] = [];
+
+  const includeTeams =
+    (!deadline.evaluatorType ||
+      deadline.evaluatorType === "Team" ||
+      deadline.evaluatorType === "Both") &&
+    (!evaluatorTypeFilter ||
+      evaluatorTypeFilter === "All" ||
+      evaluatorTypeFilter === "Team");
+
+  if (includeTeams) {
+    const teamSearchCondition = search
+      ? {
+          OR: [
+            {
+              fromProject: {
+                name: { contains: search, mode: "insensitive" as const },
+              },
+            },
+            {
+              fromProject: {
+                teamName: { contains: search, mode: "insensitive" as const },
+              },
+            },
+            {
+              toProject: {
+                name: { contains: search, mode: "insensitive" as const },
+              },
+            },
+            {
+              toProject: {
+                teamName: { contains: search, mode: "insensitive" as const },
+              },
+            },
+          ],
+        }
+      : {};
+    const relations = await findManyRelationsForEvaluations({
+      where: {
+        fromProject: { cohortYear: Number(cohortYear), hasDropped: isDropped },
+        ...teamSearchCondition,
+      },
+    });
+
+    const pTeamSubmissions = relations.map(async (relation) => {
+      const submission = await findFirstNonDraftSubmission({
+        where: {
+          deadlineId: Number(deadlineId),
+          fromProjectId: relation.fromProjectId,
+          toProjectId: relation.toProjectId,
+        },
+      });
+      return {
+        relationId: relation.id,
+        fromProject: {
+          ...relation.fromProject,
+          adviser: relation.fromProject.adviser
+            ? {
+                ...relation.fromProject.adviser,
+                ...relation.fromProject.adviser.user,
+              }
+            : null,
+        },
+        toProject: flattenProjectUsers(relation.toProject),
+        submission: submission || undefined,
+      };
+    });
+    results.push(...(await Promise.all(pTeamSubmissions)));
+  }
+
+  const includeAdvisers =
+    (deadline.evaluatorType === "Adviser" ||
+      deadline.evaluatorType === "Both") &&
+    (!evaluatorTypeFilter ||
+      evaluatorTypeFilter === "All" ||
+      evaluatorTypeFilter === "Adviser");
+
+  if (includeAdvisers) {
+    const adviserSearchCondition = search
+      ? {
+          OR: [
+            {
+              adviser: {
+                user: {
+                  name: { contains: search, mode: "insensitive" as const },
+                },
+              },
+            },
+            { name: { contains: search, mode: "insensitive" as const } },
+            { teamName: { contains: search, mode: "insensitive" as const } },
+          ],
+        }
+      : {};
+    const adviserProjects = await findManyProjectsWithUserData({
+      where: {
+        cohortYear: Number(cohortYear),
+        hasDropped: isDropped,
+        adviserId: { not: null },
+        ...adviserSearchCondition,
+      },
+    });
+
+    const pAdviserSubmissions = adviserProjects.map(async (project) => {
+      const adviser = project.adviser;
+
+      if (!adviser) {
+        return null;
+      }
+
+      const submission = await findFirstNonDraftSubmission({
+        where: {
+          deadlineId: Number(deadlineId),
+          fromUserId: adviser.userId,
+          toProjectId: project.id,
+        },
+      });
+      return {
+        relationId: `A-${project.id}`,
+        fromUser: adviser.user,
+        toProject: flattenProjectUsers(project),
+        submission: submission || undefined,
+      };
+    });
+    results.push(...(await Promise.all(pAdviserSubmissions)));
+  }
+
+  if (submissionStatus) {
+    results = results.filter((result) => {
+      const sub = result.submission;
+      if (submissionStatus == SubmissionStatusEnum.UNSUBMITTED) return !sub;
+      if (submissionStatus == SubmissionStatusEnum.SUBMITTED_LATE)
+        return sub && deadline.dueBy && sub.updatedAt > deadline.dueBy;
+      if (submissionStatus == SubmissionStatusEnum.SUBMITTED) return !!sub;
+      return true;
+    });
+  }
+
+  results.sort((a, b) => {
+    const isANum = typeof a.relationId === "number";
+    const isBNum = typeof b.relationId === "number";
+    if (isANum && isBNum)
+      return (a.relationId as number) - (b.relationId as number);
+    if (!isANum && !isBNum)
+      return String(a.relationId).localeCompare(
+        String(b.relationId),
+        undefined,
+        { numeric: true }
+      );
+    return isANum ? -1 : 1;
+  });
+
+  if (limit !== undefined && page !== undefined) {
+    const startIndex = Number(limit) * Number(page);
+    results = results.slice(startIndex, startIndex + Number(limit));
+  }
+
+  return results.map((result) => ({
+    id: result.submission?.id,
+    updatedAt: result.submission?.updatedAt,
+    ...result,
+  }));
+};

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -495,6 +495,15 @@ export const getAllEvaluationSubmissions = async (query: any) => {
   return combined;
 };
 
+export const getEvaluationSubmissions = async (query: any) => {
+  const { deadlineId } = query;
+
+  if (deadlineId) {
+    return await getEvaluationSubmissionsByDeadlineId(query);
+  }
+  return await getAllEvaluationSubmissions(query);
+};
+
 export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
   const {
     submissionStatus,

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -451,10 +451,12 @@ export const getAllEvaluationSubmissions = async (query: any) => {
         fromProject: {
           ...relation.fromProject,
           adviser: relation.fromProject.adviser
-            ? {
-                ...relation.fromProject.adviser,
-                ...relation.fromProject.adviser.user,
-              }
+            ? (() => {
+                const { user, ...adviserData } = relation.fromProject.adviser;
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { password, ...adviserUserData } = user || {};
+                return { ...adviserData, ...adviserUserData };
+              })()
             : null,
           students: flattenedStudents,
         },
@@ -490,7 +492,10 @@ export const getAllEvaluationSubmissions = async (query: any) => {
       });
       return {
         relationId: `A-${project.id}`,
-        fromUser: project.adviser?.user,
+        fromUser: project.adviser
+          ? // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            (({ password, ...rest }) => rest)(project.adviser.user as User)
+          : undefined,
         toProject: flattenProjectUsers(project),
         submission: submissions || undefined,
       };
@@ -618,16 +623,21 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
         return { ...userData, ...studentData };
       });
 
+      const adviser = relation.fromProject.adviser;
+      const sanitizedAdviser = adviser
+        ? (() => {
+            const { user, ...adviserData } = adviser as any;
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { id, password, ...userData } = (user as any) || {};
+            return { ...adviserData, ...userData };
+          })()
+        : null;
+
       return {
         relationId: relation.id,
         fromProject: {
           ...relation.fromProject,
-          adviser: relation.fromProject.adviser
-            ? {
-                ...relation.fromProject.adviser,
-                ...relation.fromProject.adviser.user,
-              }
-            : null,
+          adviser: sanitizedAdviser,
           students: flattenedStudents,
         },
         toProject: flattenProjectUsers(relation.toProject),
@@ -683,9 +693,14 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
           toProjectId: project.id,
         },
       });
+
+      const adviserUser: any = adviser.user;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { password: _password, ...sanitizedUser } = adviserUser || {};
+
       return {
         relationId: `A-${project.id}`,
-        fromUser: adviser.user,
+        fromUser: sanitizedUser,
         toProject: flattenProjectUsers(project),
         submission: submission || undefined,
       };

--- a/src/helpers/dashboard.adviser.helper.ts
+++ b/src/helpers/dashboard.adviser.helper.ts
@@ -38,6 +38,11 @@ export async function getDeadlinesByAdviserId(adviserId: number) {
           HttpStatusCode.INTERNAL_SERVER_ERROR
         );
       }
+
+      if (deadline.evaluatorType === "Team") {
+        return [];
+      }
+
       const { evaluatingMilestoneId } = deadline;
       return await Promise.all(
         projects.map(async (project) => {
@@ -133,6 +138,12 @@ export async function getProjectSubmissionsViaAdviserId(adviserId: number) {
         submissions: await Promise.all(milestoneSubmissions),
       };
     } else if (deadline.type == "Evaluation") {
+      if (deadline.evaluatorType === "Adviser") {
+        return {
+          deadline: deadline,
+          submissions: [],
+        };
+      }
       const evaluationSubmissions = relations.map(async (relation) => {
         const submission = await findFirstNonDraftSubmission({
           where: {

--- a/src/helpers/dashboard.student.helper.ts
+++ b/src/helpers/dashboard.student.helper.ts
@@ -237,7 +237,7 @@ export async function getPeerEvaluationFeedbackByStudentID(studentId: number) {
       let adviserSubmissionWrapper: AdviserFeedback | null = null;
 
       if (deadline.evaluatorType !== "Team") {
-        const pAdviserSubmission = findFirstNonDraftSubmission({
+        const pAdviserSubmission = await findFirstNonDraftSubmission({
           where: {
             deadlineId: deadline.id,
             fromUserId: adviserUser.id,

--- a/src/helpers/dashboard.student.helper.ts
+++ b/src/helpers/dashboard.student.helper.ts
@@ -75,6 +75,9 @@ export async function getDeadlinesByStudentId(studentId: number) {
         submission: submission ? submission : undefined,
       };
     } else if (deadline.type == "Evaluation") {
+      if (deadline.evaluatorType === "Adviser") {
+        return [];
+      }
       const pEvaluationDeadlines = relations.map(async (relation) => {
         const submission = await findFirstSubmission({
           where: {
@@ -195,21 +198,34 @@ export async function getPeerEvaluationFeedbackByStudentID(studentId: number) {
 
   const pProjectSubmissions = [...cohortEvaluations, ...cohortFeedbacks].map(
     async (deadline) => {
-      const pPeerSubmissions = relations.map(async (relation) => {
-        const submission = await findFirstNonDraftSubmission({
-          where: {
-            deadlineId: deadline.id,
-            fromProjectId: relation.fromProjectId,
-            toProjectId: projectId,
-          },
-        });
-        return {
-          ...submission,
-          fromProject: relation.fromProject,
-        };
-      });
+      type PeerFeedback = Partial<Submission> & {
+        fromProject: typeof relations[0]["fromProject"];
+      };
+      type AdviserFeedback = Partial<Submission> & {
+        fromUser: typeof adviserUser;
+      };
+      type FeedbackSubmission = PeerFeedback | AdviserFeedback;
 
-      const peerSubmissions = await Promise.all(pPeerSubmissions);
+      let peerSubmissions: PeerFeedback[] = [];
+
+      if (deadline.evaluatorType !== "Adviser") {
+        const pPeerSubmissions = relations.map(async (relation) => {
+          const submission = await findFirstNonDraftSubmission({
+            where: {
+              deadlineId: deadline.id,
+              fromProjectId: relation.fromProjectId,
+              toProjectId: projectId,
+            },
+          });
+
+          const peerFeedback: PeerFeedback = {
+            ...(submission || {}),
+            fromProject: relation.fromProject,
+          };
+          return peerFeedback;
+        });
+        peerSubmissions = await Promise.all(pPeerSubmissions);
+      }
 
       if (deadline.type !== "Evaluation") {
         return {
@@ -218,22 +234,31 @@ export async function getPeerEvaluationFeedbackByStudentID(studentId: number) {
         };
       }
 
-      const pAdviserSubmission = findFirstNonDraftSubmission({
-        where: {
-          deadlineId: deadline.id,
-          fromUserId: adviserUser.id,
-          toProjectId: projectId,
-        },
-      });
+      let adviserSubmissionWrapper: AdviserFeedback | null = null;
 
-      const adviserSubmission = await pAdviserSubmission;
+      if (deadline.evaluatorType !== "Team") {
+        const pAdviserSubmission = findFirstNonDraftSubmission({
+          where: {
+            deadlineId: deadline.id,
+            fromUserId: adviserUser.id,
+            toProjectId: projectId,
+          },
+        });
+
+        adviserSubmissionWrapper = {
+          fromUser: adviserUser,
+          ...(pAdviserSubmission || {}),
+        };
+      }
+
+      const finalSubmissions: FeedbackSubmission[] = [...peerSubmissions];
+      if (adviserSubmissionWrapper) {
+        finalSubmissions.push(adviserSubmissionWrapper);
+      }
 
       return {
         deadline: deadline,
-        submissions: [
-          ...peerSubmissions,
-          { fromUser: adviserUser, ...adviserSubmission },
-        ],
+        submissions: finalSubmissions,
       };
     }
   );

--- a/src/helpers/deadline.helper.ts
+++ b/src/helpers/deadline.helper.ts
@@ -5,6 +5,7 @@ import {
   DeadlineType,
   Option,
   AchievementLevel,
+  EvaluatorType,
 } from "@prisma/client";
 import { prisma } from "../client";
 import { SkylabError } from "../errors/SkylabError";
@@ -45,15 +46,19 @@ export async function createDeadline(body: {
     type: DeadlineType;
     desc?: string;
     evaluatingMilestoneId?: number; // If type == "Evaluation"
+    evaluatorType?: EvaluatorType; // If type == "Evaluation"
   };
 }) {
   const { deadline: deadlineData } = body;
-  const { evaluatingMilestoneId, cohortYear, ...deadline } = deadlineData;
+  const { evaluatingMilestoneId, evaluatorType, cohortYear, ...deadline } =
+    deadlineData;
 
   const createdDeadline = await createOneDeadline({
     data: {
       cohort: { connect: { academicYear: cohortYear } },
       ...deadline,
+      evaluatorType:
+        deadline.type === DeadlineType.Evaluation ? evaluatorType : undefined,
       evaluating:
         deadline.type === DeadlineType.Evaluation
           ? {

--- a/src/helpers/deadline.helper.ts
+++ b/src/helpers/deadline.helper.ts
@@ -31,6 +31,9 @@ export async function getManyDeadlinesWithFilter(
       cohortYear: cohortYear ?? undefined,
       name: { contains: name, mode: "insensitive" },
     },
+    orderBy: {
+      id: "asc",
+    },
   };
 
   const deadlines = await findManyDeadlines(deadlinesQuery);

--- a/src/helpers/deadline.helper.ts
+++ b/src/helpers/deadline.helper.ts
@@ -26,11 +26,16 @@ export async function getManyDeadlinesWithFilter(
 ) {
   const { cohortYear, name } = query;
 
+  const where: Prisma.DeadlineWhereInput = {};
+  if (cohortYear !== undefined && cohortYear !== null) {
+    where.cohortYear = cohortYear;
+  }
+  if (name !== undefined && name !== null) {
+    where.name = { contains: name, mode: "insensitive" };
+  }
+
   const deadlinesQuery: Prisma.DeadlineFindManyArgs = {
-    where: {
-      cohortYear: cohortYear ?? undefined,
-      name: { contains: name, mode: "insensitive" },
-    },
+    where,
     orderBy: {
       id: "asc",
     },

--- a/src/helpers/projects.helper.ts
+++ b/src/helpers/projects.helper.ts
@@ -121,7 +121,7 @@ export async function getManyProjectsLean(
       cohortYear: cohortYear,
       hasDropped: hasDropped,
     },
-    select: { id: true, name: true },
+    select: { id: true, name: true, teamName: true },
     orderBy: { id: "asc" },
   });
   return leanProjects;

--- a/src/helpers/submissions.helper.ts
+++ b/src/helpers/submissions.helper.ts
@@ -206,7 +206,7 @@ export async function getAnonymousAnswersViaAdviserID(adviserId: number) {
     async ({ sections, ...deadline }) => {
       const submissions = await findManySubmissions({
         where: {
-          id: deadline.id ? deadline.id : undefined,
+          deadlineId: deadline.id,
           isDraft: false,
           OR: [
             { toProjectId: { in: projectIds } },

--- a/src/models/relations.db.ts
+++ b/src/models/relations.db.ts
@@ -84,6 +84,54 @@ export async function findManyRelationsWithFromToProjectData({
   });
 }
 
+export async function findManyRelationsForEvaluations(
+  query: Omit<Prisma.EvaluationRelationFindManyArgs, "include">
+) {
+  return await prisma.evaluationRelation.findMany({
+    ...query,
+    orderBy: [{ fromProjectId: "asc" }, { toProjectId: "asc" }],
+    include: {
+      fromProject: {
+        include: { adviser: { include: { user: true } } },
+      },
+      toProject: {
+        include: {
+          students: { include: { user: true } },
+          adviser: { include: { user: true } },
+          mentor: { include: { user: true } },
+        },
+      },
+    },
+  });
+}
+
+export async function findManyRelationsWithFromToProjectUserData({
+  include,
+  ...query
+}: Prisma.EvaluationRelationFindManyArgs) {
+  return await prisma.evaluationRelation.findMany({
+    ...query,
+    orderBy: [{ fromProjectId: "asc" }, { toProjectId: "asc" }],
+    include: {
+      ...include,
+      fromProject: {
+        include: {
+          students: { include: { user: true } },
+          adviser: { include: { user: true } },
+          mentor: { include: { user: true } },
+        },
+      },
+      toProject: {
+        include: {
+          students: { include: { user: true } },
+          adviser: { include: { user: true } },
+          mentor: { include: { user: true } },
+        },
+      },
+    },
+  });
+}
+
 export async function deleteOneRelation(
   relation: Prisma.EvaluationRelationDeleteArgs
 ) {

--- a/src/routes/dashboard.admin.ts
+++ b/src/routes/dashboard.admin.ts
@@ -55,7 +55,6 @@ router.get(
       return throwValidationError(res, errors);
     }
     try {
-      // 2. USE THE WRAPPER HERE
       const submissions = await getEvaluationSubmissions(req.query);
       return apiResponseWrapper(res, { submissions: submissions });
     } catch (e) {

--- a/src/routes/dashboard.admin.ts
+++ b/src/routes/dashboard.admin.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import { validationResult } from "express-validator";
 import {
   getSubmissions,
-  getAllEvaluationSubmissions,
+  getEvaluationSubmissions,
   sendReminderEmail,
 } from "../helpers/dashboard.admin.helper";
 import authorizeAdmin from "../middleware/authorizeAdmin";
@@ -48,14 +48,15 @@ router.post("/send-reminders", async (req: Request, res: Response) => {
 router.get(
   "/evaluations",
   authorizeAdmin,
-  GetSubmissionsByDeadlineIDValidator, // Reuse the same validator!
+  GetSubmissionsByDeadlineIDValidator,
   async (req: Request, res: Response) => {
     const errors = validationResult(req).formatWith(errorFormatter);
     if (!errors.isEmpty()) {
       return throwValidationError(res, errors);
     }
     try {
-      const submissions = await getAllEvaluationSubmissions(req.query);
+      // 2. USE THE WRAPPER HERE
+      const submissions = await getEvaluationSubmissions(req.query);
       return apiResponseWrapper(res, { submissions: submissions });
     } catch (e) {
       return routeErrorHandler(res, e);

--- a/src/routes/dashboard.admin.ts
+++ b/src/routes/dashboard.admin.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import { validationResult } from "express-validator";
 import {
   getSubmissions,
+  getAllEvaluationSubmissions,
   sendReminderEmail,
 } from "../helpers/dashboard.admin.helper";
 import authorizeAdmin from "../middleware/authorizeAdmin";
@@ -43,5 +44,23 @@ router.post("/send-reminders", async (req: Request, res: Response) => {
     return routeErrorHandler(res, e);
   }
 });
+
+router.get(
+  "/evaluations",
+  authorizeAdmin,
+  GetSubmissionsByDeadlineIDValidator, // Reuse the same validator!
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req).formatWith(errorFormatter);
+    if (!errors.isEmpty()) {
+      return throwValidationError(res, errors);
+    }
+    try {
+      const submissions = await getAllEvaluationSubmissions(req.query);
+      return apiResponseWrapper(res, { submissions: submissions });
+    } catch (e) {
+      return routeErrorHandler(res, e);
+    }
+  }
+);
 
 export default router;

--- a/src/routes/submissions.ts
+++ b/src/routes/submissions.ts
@@ -59,7 +59,7 @@ router.get(
 router
   .get(
     "/:submissionId",
-    authorizeSignedIn,
+    authorizeSubmitter,
     async (req: Request, res: Response) => {
       const { submissionId } = req.params;
       try {

--- a/src/validators/deadline.validator.ts
+++ b/src/validators/deadline.validator.ts
@@ -1,4 +1,4 @@
-import { DeadlineType } from "@prisma/client";
+import { DeadlineType, EvaluatorType } from "@prisma/client";
 import { body, param } from "express-validator";
 import { getOneDeadlineById } from "../helpers/deadline.helper";
 import {
@@ -38,4 +38,8 @@ export const CreateDeadlineValidator = [
         return Promise.reject("There is no such milestone to evaluate");
       }
     }),
+  body("deadline.evaluatorType")
+    .if(body("deadline.type").equals("Evaluation"))
+    .notEmpty()
+    .isIn(Object.values(EvaluatorType)),
 ];


### PR DESCRIPTION
## Description 

This pull request introduces the concept of evaluator types for deadlines, refines how submissions and answers are filtered and accessed. 

**Evaluator Type Integration and Schema Updates**

* Added a new `EvaluatorType` enum (`Adviser`, `Team`, `Both`) to both the Prisma schema and database, and linked it to the `Deadline` model. This allows deadlines to specify who is responsible for evaluation. 

**Business Logic and Helper Enhancements**

* Updated deadline creation and filtering logic to support the new `evaluatorType` field and improved query flexibility in deadline helpers. 
* Modified adviser and student dashboard helpers to respect the `evaluatorType` field, ensuring only relevant evaluations and submissions are returned based on the evaluator's role. 
* Improved seeding logic to set `evaluatorType` appropriately for evaluation deadlines. 

**Submission and Answer Security Improvements**

* Enhanced `getSubmissionBySubmissionId` to filter out anonymous answers for unauthorized users, ensuring only authors and admins see all answers. 
* Improved the retrieval of anonymous answers for advisers and students by parsing questions and ensuring only relevant answers are returned, and by restricting adviser access to their own projects.