### PR TITLE
fix: fix admin dashboard filter

### DIFF
--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -330,7 +330,11 @@ export const getCollatedMilestoneSubmissions = async (
               }
 
               if (submissionStatus === SubmissionStatusEnum.SUBMITTED) {
-                return !!response.submissionId;
+                return (
+                  !!response.submissionId &&
+                  !!response.submittedAt &&
+                  response.submittedAt < deadline.dueBy
+                );
               }
 
               if (submissionStatus === SubmissionStatusEnum.SUBMITTED_LATE) {
@@ -511,7 +515,11 @@ export const getCollatedMilestoneSubmissions = async (
           return !response.submissionId;
         }
         if (submissionStatus === SubmissionStatusEnum.SUBMITTED) {
-          return !!response.submissionId;
+          return (
+            !!response.submissionId &&
+            !!response.submittedAt &&
+            response.submittedAt < deadline.dueBy
+          );
         }
         if (submissionStatus === SubmissionStatusEnum.SUBMITTED_LATE) {
           return (
@@ -741,7 +749,9 @@ export const getSubmissionsByDeadlineId = async (
           result.submission && result.submission.updatedAt > deadline.dueBy
         );
       } else if (submissionStatus == SubmissionStatusEnum.SUBMITTED) {
-        return !!result.submission;
+        return (
+          !!result.submission && result.submission.updatedAt < deadline.dueBy
+        );
       }
     });
 
@@ -1152,7 +1162,8 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
       if (submissionStatus == SubmissionStatusEnum.UNSUBMITTED) return !sub;
       if (submissionStatus == SubmissionStatusEnum.SUBMITTED_LATE)
         return sub && deadline.dueBy && sub.updatedAt > deadline.dueBy;
-      if (submissionStatus == SubmissionStatusEnum.SUBMITTED) return !!sub;
+      if (submissionStatus == SubmissionStatusEnum.SUBMITTED)
+        return !!sub && deadline.dueBy && sub.updatedAt < deadline.dueBy;
       return true;
     });
   }

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -333,7 +333,7 @@ export const getCollatedMilestoneSubmissions = async (
                 return (
                   !!response.submissionId &&
                   !!response.submittedAt &&
-                  response.submittedAt < deadline.dueBy
+                  response.submittedAt <= deadline.dueBy
                 );
               }
 
@@ -518,7 +518,7 @@ export const getCollatedMilestoneSubmissions = async (
           return (
             !!response.submissionId &&
             !!response.submittedAt &&
-            response.submittedAt < deadline.dueBy
+            response.submittedAt <= deadline.dueBy
           );
         }
         if (submissionStatus === SubmissionStatusEnum.SUBMITTED_LATE) {
@@ -750,7 +750,7 @@ export const getSubmissionsByDeadlineId = async (
         );
       } else if (submissionStatus == SubmissionStatusEnum.SUBMITTED) {
         return (
-          !!result.submission && result.submission.updatedAt < deadline.dueBy
+          !!result.submission && result.submission.updatedAt <= deadline.dueBy
         );
       }
     });
@@ -1163,7 +1163,7 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
       if (submissionStatus == SubmissionStatusEnum.SUBMITTED_LATE)
         return sub && deadline.dueBy && sub.updatedAt > deadline.dueBy;
       if (submissionStatus == SubmissionStatusEnum.SUBMITTED)
-        return !!sub && deadline.dueBy && sub.updatedAt < deadline.dueBy;
+        return !!sub && deadline.dueBy && sub.updatedAt <= deadline.dueBy;
       return true;
     });
   }


### PR DESCRIPTION
## Context

Previously, there was a bug in the administrator dashboard when filtering of the issues, e.g. missing entries when filtering for `Submitted Late` or `Unsubmitted` in milestones. 

## Description

This PR made the following fixes: 

-  Sends `submissionStatus` when a specific milestone/evaluation is selected to prevent hidden stale filters from affecting `All Milestones` and `All Evaluations`
- Makes `Submitted` and `Submitted_Late` mutually exclusive - where now `Submitted` means non-draft submission with `updatedAt` <= `dueBy`, keeping it seperate from `Submitted_Late`