### PR TITLE
fix: flatten admin dashboard payload to include id attribute

### DIFF
--- a/__tests__/helpers/dashboard.admin.helper.unit.test.ts
+++ b/__tests__/helpers/dashboard.admin.helper.unit.test.ts
@@ -123,7 +123,8 @@ describe("flattenProjectUsers function unit test", () => {
 
     const expectedFlattened = {
       adviser: {
-        id: 37,
+        adviserId: 37,
+        id: 439,
         userId: 439,
         submitterId: null,
         matricNo: "A0622992K",
@@ -138,7 +139,8 @@ describe("flattenProjectUsers function unit test", () => {
         selfIntro: "Ullam et maiores et.",
       },
       mentor: {
-        id: 37,
+        mentorId: 37,
+        id: 539,
         userId: 539,
         cohortYear: 2025,
         name: "Mireille Bernhard",
@@ -165,6 +167,7 @@ describe("flattenProjectUsers function unit test", () => {
       students: [
         {
           id: 37,
+          studentId: 37,
           userId: 37,
           projectId: 37,
           nusnetId: "e0612289",
@@ -181,6 +184,7 @@ describe("flattenProjectUsers function unit test", () => {
         },
         {
           id: 364,
+          studentId: 364,
           userId: 364,
           projectId: 37,
           nusnetId: "e0368678",

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -24,6 +24,7 @@ import {
 } from "../models/submissions.db";
 import { SENDER, GET_HTML_CONTENT_REMINDER } from "../utils/Emails";
 import { prisma } from "../client";
+import { removePasswordFromUser } from "./users.helper";
 
 export enum SubmissionStatusEnum {
   UNSUBMITTED = "Unsubmitted",
@@ -99,6 +100,39 @@ export type CollatedEvaluationDeadlineResponse = {
   questions: CollatedEvaluationQuestionResponse[];
 };
 
+const withoutPassword = (user?: User | null) => {
+  if (!user) return {};
+
+  return removePasswordFromUser(user);
+};
+
+const flattenStudentUser = (student: Student & { user?: User | null }) => {
+  const { user, id: studentId, ...studentData } = student;
+  return {
+    studentId,
+    ...withoutPassword(user),
+    ...studentData,
+  };
+};
+
+const flattenAdviserUser = (adviser: Adviser & { user?: User | null }) => {
+  const { user, id: adviserId, ...adviserData } = adviser;
+  return {
+    adviserId,
+    ...withoutPassword(user),
+    ...adviserData,
+  };
+};
+
+const flattenMentorUser = (mentor: Mentor & { user?: User | null }) => {
+  const { user, id: mentorId, ...mentorData } = mentor;
+  return {
+    mentorId,
+    ...withoutPassword(user),
+    ...mentorData,
+  };
+};
+
 export function flattenProjectUsers(
   project: Project & {
     students?: (Student & {
@@ -119,28 +153,14 @@ export function flattenProjectUsers(
   const { students, adviser, mentor, ...projectData } = project;
 
   const flattenedStudents = students
-    ? students.map((student) => {
-        const { user, ...studentData } = student;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { id, password, ...userData } = user;
-        return {
-          ...userData,
-          ...studentData,
-        };
-      })
+    ? students.map((student) => flattenStudentUser(student))
     : [];
 
   let tempMentorAdviser;
 
   if (adviser) {
-    const { user: adviserUser, ...adviserData } = adviser;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id, password, ...adviserUserData } = adviserUser;
     tempMentorAdviser = {
-      adviser: {
-        ...adviserData,
-        ...adviserUserData,
-      },
+      adviser: flattenAdviserUser(adviser),
     };
   } else {
     tempMentorAdviser = {
@@ -149,15 +169,9 @@ export function flattenProjectUsers(
   }
 
   if (mentor) {
-    const { user: mentorUser, ...mentorData } = mentor;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id, password, ...mentorUserData } = mentorUser;
     tempMentorAdviser = {
       ...tempMentorAdviser,
-      mentor: {
-        ...mentorUserData,
-        ...mentorData,
-      },
+      mentor: flattenMentorUser(mentor),
     };
   } else {
     tempMentorAdviser = {
@@ -881,24 +895,16 @@ export const getAllEvaluationSubmissions = async (query: any) => {
 
       const rawStudents =
         projectsWithStudentsMap.get(relation.fromProjectId) || [];
-      const flattenedStudents = rawStudents.map((student) => {
-        const { user, ...studentData } = student;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { id, password, ...userData } = user || {};
-        return { ...userData, ...studentData };
-      });
+      const flattenedStudents = rawStudents.map((student) =>
+        flattenStudentUser(student)
+      );
 
       return {
         relationId: relation.id,
         fromProject: {
           ...relation.fromProject,
           adviser: relation.fromProject.adviser
-            ? (() => {
-                const { user, ...adviserData } = relation.fromProject.adviser;
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const { password, ...adviserUserData } = user || {};
-                return { ...adviserData, ...adviserUserData };
-              })()
+            ? flattenAdviserUser(relation.fromProject.adviser)
             : null,
           students: flattenedStudents,
         },
@@ -1059,22 +1065,12 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
 
       const rawStudents =
         projectsWithStudentsMap.get(relation.fromProjectId) || [];
-      const flattenedStudents = rawStudents.map((student) => {
-        const { user, ...studentData } = student;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { id, password, ...userData } = user || {};
-        return { ...userData, ...studentData };
-      });
+      const flattenedStudents = rawStudents.map((student) =>
+        flattenStudentUser(student)
+      );
 
       const adviser = relation.fromProject.adviser;
-      const sanitizedAdviser = adviser
-        ? (() => {
-            const { user, ...adviserData } = adviser as any;
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { id, password, ...userData } = (user as any) || {};
-            return { ...adviserData, ...userData };
-          })()
-        : null;
+      const sanitizedAdviser = adviser ? flattenAdviserUser(adviser) : null;
 
       return {
         relationId: relation.id,

--- a/src/models/deadline.db.ts
+++ b/src/models/deadline.db.ts
@@ -141,6 +141,7 @@ export async function createOneDeadline(query: Prisma.DeadlineCreateArgs) {
   const createdDeadline = await prisma.deadline.create(query);
   const deadlineToReturn = await prisma.deadline.findUnique({
     where: { id: createdDeadline.id },
+    include: { evaluating: true },
   });
   return deadlineToReturn;
 }


### PR DESCRIPTION
# Description

This PR aims to resolve the bug where the links of the student / adviser / mentor names are not correct (they point to a wrong user).

To replicate,

a. Click on administrator dashboard, and then click on any adviser, the hyperlink goes to another person's profile.

b. Click on the user (Kabir for example it goes to https://nusskylab-v2-dev.comp.nus.edu.sg/users/12660 instead of https://nusskylab-v2-dev.comp.nus.edu.sg/users/14969) which shows no user is found.

<img width="2318" height="1030" alt="image" src="https://github.com/user-attachments/assets/ffc69bed-a244-4c39-b14c-9630a1ca31e1" />
