### PR TITLE
fix: enforce object-level authorization on peer-review dashboard routes

### DIFF
--- a/__tests__/middleware/authorizeSelfRole.unit.test.ts
+++ b/__tests__/middleware/authorizeSelfRole.unit.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import supertest from "supertest";
+import jwt from "jsonwebtoken";
+import app from "../../src/server";
+import * as usersDb from "../../src/models/users.db";
+import * as dashboardStudentHelper from "../../src/helpers/dashboard.student.helper";
+
+const BASE_URL = "/api/dashboard/student";
+
+describe("authorizeSelfRole (regression for IDOR on /:studentId routes)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const withCookie = (req: supertest.Test) =>
+    req.set("Cookie", ["token=validtoken"]);
+
+  it("denies a student requesting another student's evaluations-feedbacks", async () => {
+    jest.spyOn(jwt, "verify").mockReturnValue({ id: 1 } as never);
+    jest.spyOn(usersDb, "findUniqueUserWithRoleData").mockResolvedValue({
+      id: 1,
+      administrator: {},
+      student: { id: 111 },
+    } as never);
+    const helperSpy = jest.spyOn(
+      dashboardStudentHelper,
+      "getPeerEvaluationFeedbackByStudentID"
+    );
+
+    const response = await withCookie(
+      supertest(app).get(`${BASE_URL}/999/evaluations-feedbacks`)
+    );
+
+    expect(response.status).toBe(401);
+    expect(helperSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows a student requesting their own evaluations-feedbacks", async () => {
+    jest.spyOn(jwt, "verify").mockReturnValue({ id: 1 } as never);
+    jest.spyOn(usersDb, "findUniqueUserWithRoleData").mockResolvedValue({
+      id: 1,
+      administrator: {},
+      student: { id: 111 },
+    } as never);
+    jest
+      .spyOn(dashboardStudentHelper, "getPeerEvaluationFeedbackByStudentID")
+      .mockResolvedValue([] as never);
+
+    const response = await withCookie(
+      supertest(app).get(`${BASE_URL}/111/evaluations-feedbacks`)
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("allows an admin to request any student's evaluations-feedbacks", async () => {
+    jest.spyOn(jwt, "verify").mockReturnValue({ id: 2 } as never);
+    jest.spyOn(usersDb, "findUniqueUserWithRoleData").mockResolvedValue({
+      id: 2,
+      administrator: { id: 1 },
+    } as never);
+    jest
+      .spyOn(dashboardStudentHelper, "getPeerEvaluationFeedbackByStudentID")
+      .mockResolvedValue([] as never);
+
+    const response = await withCookie(
+      supertest(app).get(`${BASE_URL}/999/evaluations-feedbacks`)
+    );
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/middleware/authorizeSelfRole.ts
+++ b/src/middleware/authorizeSelfRole.ts
@@ -1,0 +1,55 @@
+import { SkylabError } from "../errors/SkylabError";
+import { HttpStatusCode } from "../utils/HTTP_Status_Codes";
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { findUniqueUserWithRoleData } from "../models/users.db";
+
+/**
+ * Builds middleware that only allows admins or the student/adviser/mentor
+ * whose own id matches the :paramName route param (e.g. GET /:studentId/deadlines
+ * should only be readable by that student, not any signed-in user).
+ */
+const authorizeSelfRole = (
+  role: "student" | "adviser" | "mentor",
+  paramName: string
+) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const token = req?.cookies?.token;
+      if (!token || typeof token !== "string") {
+        return res
+          .status(HttpStatusCode.UNAUTHORIZED)
+          .send("Authentication failed");
+      }
+
+      const jwtData = jwt.verify(
+        token,
+        process.env.JWT_SECRET ?? "jwt_secret"
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ) as any;
+      const userData = await findUniqueUserWithRoleData({
+        where: { id: Number(jwtData.id) },
+      });
+      res.locals.userData = userData;
+
+      // allow admins
+      if (userData.administrator?.id) return next();
+
+      // only allow if accessing own role data
+      const roleId = req.params[paramName];
+      if (userData[role]?.id === Number(roleId)) return next();
+
+      return res
+        .status(HttpStatusCode.UNAUTHORIZED)
+        .send("You are not authorized to view this page");
+    } catch (e) {
+      if (!(e instanceof SkylabError)) {
+        res.status(HttpStatusCode.INTERNAL_SERVER_ERROR).send(e.message);
+      } else {
+        res.status(e.statusCode).send(e.message);
+      }
+    }
+  };
+};
+
+export default authorizeSelfRole;

--- a/src/routes/dashboard.adviser.ts
+++ b/src/routes/dashboard.adviser.ts
@@ -3,17 +3,18 @@ import {
   getDeadlinesByAdviserId,
   getProjectSubmissionsViaAdviserId,
 } from "../helpers/dashboard.adviser.helper";
-import authorizeSignedIn from "../middleware/authorizeSignedIn";
+import authorizeSelfRole from "../middleware/authorizeSelfRole";
 import {
   apiResponseWrapper,
   routeErrorHandler,
 } from "../utils/ApiResponseWrapper";
 
 const router = Router();
+const authorizeSelfAdviser = authorizeSelfRole("adviser", "adviserId");
 
 router.get(
   "/:adviserId/deadlines",
-  authorizeSignedIn,
+  authorizeSelfAdviser,
   async (req: Request, res: Response) => {
     const { adviserId } = req.params;
     try {
@@ -27,7 +28,7 @@ router.get(
 
 router.get(
   "/:adviserId/submissions",
-  authorizeSignedIn,
+  authorizeSelfAdviser,
   async (req: Request, res: Response) => {
     const { adviserId } = req.params;
     try {

--- a/src/routes/dashboard.mentor.ts
+++ b/src/routes/dashboard.mentor.ts
@@ -1,16 +1,17 @@
 import { Request, Response, Router } from "express";
 import { getProjectMilestonesByMentorId } from "../helpers/dashboard.mentor";
-import authorizeSignedIn from "../middleware/authorizeSignedIn";
+import authorizeSelfRole from "../middleware/authorizeSelfRole";
 import {
   apiResponseWrapper,
   routeErrorHandler,
 } from "../utils/ApiResponseWrapper";
 
 const router = Router();
+const authorizeSelfMentor = authorizeSelfRole("mentor", "mentorId");
 
 router.get(
   "/:mentorId/submissions",
-  authorizeSignedIn,
+  authorizeSelfMentor,
   async (req: Request, res: Response) => {
     const { mentorId } = req.params;
     try {

--- a/src/routes/dashboard.student.ts
+++ b/src/routes/dashboard.student.ts
@@ -3,17 +3,18 @@ import {
   getDeadlinesByStudentId,
   getPeerEvaluationFeedbackByStudentID,
 } from "../helpers/dashboard.student.helper";
-import authorizeSignedIn from "../middleware/authorizeSignedIn";
+import authorizeSelfRole from "../middleware/authorizeSelfRole";
 import {
   apiResponseWrapper,
   routeErrorHandler,
 } from "../utils/ApiResponseWrapper";
 
 const router = Router();
+const authorizeSelfStudent = authorizeSelfRole("student", "studentId");
 
 router.get(
   "/:studentId/deadlines",
-  authorizeSignedIn,
+  authorizeSelfStudent,
   async (req: Request, res: Response) => {
     const { studentId } = req.params;
     try {
@@ -27,7 +28,7 @@ router.get(
 
 router.get(
   "/:studentId/evaluations-feedbacks",
-  authorizeSignedIn,
+  authorizeSelfStudent,
   async (req: Request, res: Response) => {
     const { studentId } = req.params;
     try {

--- a/src/routes/submissions.ts
+++ b/src/routes/submissions.ts
@@ -8,6 +8,7 @@ import {
 } from "../helpers/submissions.helper";
 import authorizeSignedIn from "../middleware/authorizeSignedIn";
 import authorizeSubmitter from "../middleware/authorizeSubmitter";
+import authorizeSelfRole from "../middleware/authorizeSelfRole";
 import {
   apiResponseWrapper,
   routeErrorHandler,
@@ -34,7 +35,7 @@ router.post("/", authorizeSignedIn, async (req: Request, res: Response) => {
 
 router.get(
   "/student/:studentId/anonymous-questions",
-  authorizeSignedIn,
+  authorizeSelfRole("student", "studentId"),
   async (req: Request, res: Response) => {
     const { studentId } = req.params;
     try {
@@ -49,7 +50,7 @@ router.get(
 
 router.get(
   "/adviser/:adviserId/anonymous-questions",
-  authorizeSignedIn,
+  authorizeSelfRole("adviser", "adviserId"),
   async (req: Request, res: Response) => {
     const { adviserId } = req.params;
     try {


### PR DESCRIPTION
## Summary
- `/dashboard/student/:studentId/*`, `/dashboard/adviser/:adviserId/*`,
  `/dashboard/mentor/:mentorId/*`, and
  `/submissions/{student,adviser}/:id/anonymous-questions` only checked
  `authorizeSignedIn` (any valid session), not that the caller owned the
  id in the URL. Any signed-in student/adviser/mentor could read
  another's peer-evaluation feedback, deadlines, or anonymous answers by
  changing the id.
- Adds `authorizeSelfRole` (admin bypass + self-id check) and wires it
  into the affected routes.

## Related
- Relates to orbital-skylab/skylab-frontend#102

## Test plan
- [x] `authorizeSelfRole.unit.test.ts`: denies cross-user access, allows
      own data, allows admin
- [x] ESLint / Prettier clean
- [ ] Maintainer to verify against a non-public account before closing
      #102, per the issue's own note