### PR TITLE
fix: fix missing admin unsubmitted milestone entries

### DIFF
--- a/__tests__/helpers/dashboard.admin.helper.unit.test.ts
+++ b/__tests__/helpers/dashboard.admin.helper.unit.test.ts
@@ -17,7 +17,12 @@ import * as DashboardAdminHelpers from "../../src/helpers/dashboard.admin.helper
 import {
   flattenProjectUsers,
   getSubmissions,
+  getSubmissionsByDeadlineId,
+  SubmissionStatusEnum,
 } from "../../src/helpers/dashboard.admin.helper";
+import * as DeadlineDb from "../../src/models/deadline.db";
+import * as ProjectsDb from "../../src/models/projects.db";
+import * as SubmissionsDb from "../../src/models/submissions.db";
 
 afterEach(() => {
   jest.resetAllMocks();
@@ -248,5 +253,85 @@ describe("getSubmissions helper unit test", () => {
     expect(getSubmissionsByDeadlineIdSpy).not.toHaveBeenCalled();
 
     expect(result).toEqual(mockProjects);
+  });
+});
+
+describe("getSubmissionsByDeadlineId helper unit test", () => {
+  const buildProject = (id: number, hasDropped = false) =>
+    ({
+      id,
+      name: `Project ${id}`,
+      teamName: `Team ${id}`,
+      adviserId: null,
+      mentorId: null,
+      achievement: AchievementLevel.Vostok,
+      cohortYear: 2025,
+      proposalPdf: null,
+      posterUrl: null,
+      videoUrl: null,
+      hasDropped,
+      students: [],
+      adviser: null,
+      mentor: null,
+    } as any);
+
+  const buildSubmission = (projectId: number) =>
+    ({
+      id: projectId,
+      deadlineId: 1,
+      isDraft: false,
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      fromProjectId: projectId,
+      toProjectId: null,
+      fromUserId: null,
+      toUserId: null,
+    } as any);
+
+  it("filters and sorts submissions before paginating with a default first page", async () => {
+    const projects = Array.from({ length: 56 }, (_, index) =>
+      buildProject(index + 1)
+    );
+    const findManyProjectsSpy = jest
+      .spyOn(ProjectsDb, "findManyProjectsWithUserData")
+      .mockResolvedValueOnce(projects);
+    const findFirstNonDraftSubmissionSpy = jest
+      .spyOn(SubmissionsDb, "findFirstNonDraftSubmission")
+      .mockImplementation(async ({ where }: any) => {
+        const projectId = where.fromProjectId;
+        return projectId <= 50 ? buildSubmission(projectId) : null;
+      });
+
+    jest.spyOn(DeadlineDb, "findUniqueDeadline").mockResolvedValueOnce({
+      id: 1,
+      name: "Milestone 1",
+      cohortYear: 2025,
+      createdOn: new Date("2025-01-01T00:00:00.000Z"),
+      dueBy: new Date("2025-02-01T00:00:00.000Z"),
+      desc: null,
+      type: "Milestone",
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      evaluatingMilestoneId: null,
+      evaluatorType: null,
+    } as any);
+
+    const result = await getSubmissionsByDeadlineId({
+      cohortYear: 2025,
+      deadlineId: 1,
+      dropped: "false",
+      submissionStatus: SubmissionStatusEnum.UNSUBMITTED,
+      limit: 2,
+    });
+
+    expect(findManyProjectsSpy).toHaveBeenCalledWith({
+      where: {
+        cohortYear: 2025,
+        hasDropped: false,
+        name: undefined,
+      },
+    });
+    expect(findFirstNonDraftSubmissionSpy).toHaveBeenCalledTimes(56);
+    expect(result.map((submission) => submission.fromProject.id)).toEqual([
+      51, 52,
+    ]);
   });
 });

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -674,8 +674,6 @@ export const getSubmissionsByDeadlineId = async (
       cohortYear: cohortYear,
       name: search ? { contains: search } : undefined,
     },
-    take: query.limit ?? undefined,
-    skip: query.limit && query.page ? limit * page : undefined,
   });
   const projectIds = projects.map(({ id }) => id);
 
@@ -745,17 +743,8 @@ export const getSubmissionsByDeadlineId = async (
     }
   });
 
-  if (!submissionStatus) {
-    return results.map((result) => {
-      const { submission, ...resultData } = result;
-      return {
-        id: submission ? submission.id : undefined,
-        updatedAt: submission ? submission.updatedAt : undefined,
-        ...resultData,
-      };
-    });
-  } else {
-    const filteredResult = results.filter((result) => {
+  if (submissionStatus) {
+    results = results.filter((result) => {
       if (submissionStatus == SubmissionStatusEnum.UNSUBMITTED) {
         return !result.submission;
       } else if (submissionStatus == SubmissionStatusEnum.SUBMITTED_LATE) {
@@ -768,16 +757,23 @@ export const getSubmissionsByDeadlineId = async (
         );
       }
     });
-
-    return filteredResult.map((result) => {
-      const { submission, ...resultData } = result;
-      return {
-        id: submission ? submission.id : undefined,
-        updatedAt: submission ? submission.updatedAt : undefined,
-        ...resultData,
-      };
-    });
   }
+
+  results.sort((a, b) => a.fromProject.id - b.fromProject.id);
+
+  if (limit !== undefined && page !== undefined) {
+    const startIndex = Number(limit) * Number(page);
+    results = results.slice(startIndex, startIndex + Number(limit));
+  }
+
+  return results.map((result) => {
+    const { submission, ...resultData } = result;
+    return {
+      id: submission ? submission.id : undefined,
+      updatedAt: submission ? submission.updatedAt : undefined,
+      ...resultData,
+    };
+  });
 };
 
 export async function sendReminderEmail(

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -668,10 +668,12 @@ export const getSubmissionsByDeadlineId = async (
     dropped,
   } = query;
 
+  const isDropped = dropped === "true" || dropped === true;
   const deadline = await findUniqueDeadline({ where: { id: deadlineId } });
   const projects = await findManyProjectsWithUserData({
     where: {
       cohortYear: cohortYear,
+      hasDropped: isDropped,
       name: search ? { contains: search } : undefined,
     },
   });

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -761,8 +761,8 @@ export const getSubmissionsByDeadlineId = async (
 
   results.sort((a, b) => a.fromProject.id - b.fromProject.id);
 
-  if (limit !== undefined && page !== undefined) {
-    const startIndex = Number(limit) * Number(page);
+  if (limit !== undefined) {
+    const startIndex = Number(limit) * Number(page ?? 0);
     results = results.slice(startIndex, startIndex + Number(limit));
   }
 


### PR DESCRIPTION
# Context

Previously, there was an error when viewing unsubmitted teams in the administrator dashboard, as shown below.

<img width="2280" height="870" alt="image" src="https://github.com/user-attachments/assets/252b10a9-0905-4021-bab4-fa1f996b71e1" />

After testing, the issue was caused by pagination. The backend was only checking the first 50 projects before applying the submission status filter, so `Unsubmitted` or `Submitted Late` entries outside the first page could be missing.

# Changes Made

The bug was caused by the backend ordering of operations. Previously, it did: `paginate projects` -> `compute/filter submission status`

This PR changes the order to: `compute/filter submission status` -> `sort by project id` -> `paginate`

This ensures the status filter is applied across the whole cohort before the result is paginated.

# Concerns

This may slightly affect loading time because the backend now checks all matching projects before slicing the result to 50. For this dashboard, this tradeoff is made for correctness, and typical cohort sizes should still be fine.

If performance becomes an issue later, the better fix would be to optimize the backend query rather than paginate before filtering.