### PR TITLE
feat: add feedback evaluator support and admin dashboard API

### DIFF
--- a/__tests__/helpers/dashboard.admin.helper.unit.test.ts
+++ b/__tests__/helpers/dashboard.admin.helper.unit.test.ts
@@ -383,7 +383,7 @@ describe("getSubmissionsByDeadlineId helper unit test", () => {
       evaluatorType: null,
     } as any);
 
-    await getSubmissionsByDeadlineId({
+    const result = await getSubmissionsByDeadlineId({
       cohortYear: 2025,
       deadlineId: 4,
       dropped: "false",
@@ -396,6 +396,43 @@ describe("getSubmissionsByDeadlineId helper unit test", () => {
         toUserId: adviserUserId,
       },
     });
+    expect(result[0].toUser).toEqual(
+      expect.not.objectContaining({ password: expect.anything() })
+    );
+  });
+
+  it("skips feedback submission queries for projects without advisers", async () => {
+    const project = buildProject(1);
+
+    jest
+      .spyOn(ProjectsDb, "findManyProjectsWithUserData")
+      .mockResolvedValueOnce([project]);
+    const findFirstNonDraftSubmissionSpy = jest.spyOn(
+      SubmissionsDb,
+      "findFirstNonDraftSubmission"
+    );
+
+    jest.spyOn(DeadlineDb, "findUniqueDeadline").mockResolvedValueOnce({
+      id: 4,
+      name: "Feedback 1",
+      cohortYear: 2025,
+      createdOn: new Date("2025-01-01T00:00:00.000Z"),
+      dueBy: new Date("2025-02-01T00:00:00.000Z"),
+      desc: null,
+      type: "Feedback",
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      evaluatingMilestoneId: null,
+      evaluatorType: null,
+    } as any);
+
+    const result = await getSubmissionsByDeadlineId({
+      cohortYear: 2025,
+      deadlineId: 4,
+      dropped: "false",
+    });
+
+    expect(findFirstNonDraftSubmissionSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
   });
 });
 

--- a/__tests__/helpers/dashboard.admin.helper.unit.test.ts
+++ b/__tests__/helpers/dashboard.admin.helper.unit.test.ts
@@ -16,12 +16,14 @@ import {
 import * as DashboardAdminHelpers from "../../src/helpers/dashboard.admin.helper";
 import {
   flattenProjectUsers,
+  getFeedbackSubmissions,
   getSubmissions,
   getSubmissionsByDeadlineId,
   SubmissionStatusEnum,
 } from "../../src/helpers/dashboard.admin.helper";
 import * as DeadlineDb from "../../src/models/deadline.db";
 import * as ProjectsDb from "../../src/models/projects.db";
+import * as RelationsDb from "../../src/models/relations.db";
 import * as SubmissionsDb from "../../src/models/submissions.db";
 
 afterEach(() => {
@@ -333,5 +335,221 @@ describe("getSubmissionsByDeadlineId helper unit test", () => {
     expect(result.map((submission) => submission.fromProject.id)).toEqual([
       51, 52,
     ]);
+  });
+
+  it("uses the adviser's user id when fetching feedback submissions", async () => {
+    const adviserUserId = 900;
+    const project = {
+      ...buildProject(1),
+      adviserId: 10,
+      adviser: {
+        id: 10,
+        userId: adviserUserId,
+        cohortYear: 2025,
+        nusnetId: "e0123456",
+        matricNo: "A0123456A",
+        user: {
+          id: adviserUserId,
+          name: "Adviser One",
+          email: "adviser@example.com",
+          password: "password",
+          profilePicUrl: null,
+          githubUrl: null,
+          linkedinUrl: null,
+          personalSiteUrl: null,
+          selfIntro: null,
+          submitterId: null,
+        },
+      },
+    };
+
+    jest
+      .spyOn(ProjectsDb, "findManyProjectsWithUserData")
+      .mockResolvedValueOnce([project]);
+    const findFirstNonDraftSubmissionSpy = jest
+      .spyOn(SubmissionsDb, "findFirstNonDraftSubmission")
+      .mockResolvedValueOnce(null);
+
+    jest.spyOn(DeadlineDb, "findUniqueDeadline").mockResolvedValueOnce({
+      id: 4,
+      name: "Feedback 1",
+      cohortYear: 2025,
+      createdOn: new Date("2025-01-01T00:00:00.000Z"),
+      dueBy: new Date("2025-02-01T00:00:00.000Z"),
+      desc: null,
+      type: "Feedback",
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      evaluatingMilestoneId: null,
+      evaluatorType: null,
+    } as any);
+
+    await getSubmissionsByDeadlineId({
+      cohortYear: 2025,
+      deadlineId: 4,
+      dropped: "false",
+    });
+
+    expect(findFirstNonDraftSubmissionSpy).toHaveBeenCalledWith({
+      where: {
+        deadlineId: 4,
+        fromProjectId: project.id,
+        toUserId: adviserUserId,
+      },
+    });
+  });
+});
+
+describe("getFeedbackSubmissions helper unit test", () => {
+  it("reverses evaluation relations for team feedback", async () => {
+    const buildProject = (id: number) =>
+      ({
+        id,
+        name: `Project ${id}`,
+        teamName: `Team ${id}`,
+        adviserId: null,
+        mentorId: null,
+        achievement: AchievementLevel.Vostok,
+        cohortYear: 2025,
+        proposalPdf: null,
+        posterUrl: null,
+        videoUrl: null,
+        hasDropped: false,
+        students: [],
+        adviser: null,
+        mentor: null,
+      } as any);
+    const evaluator = buildProject(1);
+    const evaluatee = buildProject(2);
+
+    jest.spyOn(DeadlineDb, "findUniqueDeadline").mockResolvedValueOnce({
+      id: 4,
+      name: "Feedback 1",
+      cohortYear: 2025,
+      createdOn: new Date("2025-01-01T00:00:00.000Z"),
+      dueBy: new Date("2025-02-01T00:00:00.000Z"),
+      desc: null,
+      type: "Feedback",
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      evaluatingMilestoneId: null,
+      evaluatorType: "Team",
+    } as any);
+    jest
+      .spyOn(RelationsDb, "findManyRelationsForEvaluations")
+      .mockResolvedValueOnce([
+        {
+          id: 7,
+          fromProjectId: evaluator.id,
+          toProjectId: evaluatee.id,
+          adviserId: null,
+          fromProject: evaluator,
+          toProject: evaluatee,
+        },
+      ] as any);
+    jest
+      .spyOn(ProjectsDb, "findManyProjectsWithUserData")
+      .mockResolvedValueOnce([evaluatee])
+      .mockResolvedValueOnce([]);
+    jest
+      .spyOn(SubmissionsDb, "findFirstNonDraftSubmission")
+      .mockResolvedValueOnce(null);
+
+    const result = await getFeedbackSubmissions({
+      cohortYear: 2025,
+      deadlineId: 4,
+      dropped: "false",
+      evaluatorTypeFilter: "Team",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      relationId: "F-T-7",
+      fromProject: { id: evaluatee.id },
+      toProject: { id: evaluator.id },
+    });
+  });
+
+  it("returns a submitted Team feedback response addressed to its adviser", async () => {
+    const adviserUser = {
+      id: 11,
+      name: "Adviser One",
+      email: "adviser@example.com",
+      password: "password",
+    };
+    const teamProject = {
+      id: 2,
+      name: "Project 2",
+      teamName: "Team 2",
+      adviserId: 12,
+      mentorId: null,
+      achievement: AchievementLevel.Vostok,
+      cohortYear: 2025,
+      proposalPdf: null,
+      posterUrl: null,
+      videoUrl: null,
+      hasDropped: false,
+      students: [],
+      mentor: null,
+      adviser: {
+        id: 12,
+        userId: adviserUser.id,
+        cohortYear: 2025,
+        nusnetId: "e0123456",
+        matricNo: "A0123456A",
+        user: adviserUser,
+      },
+    };
+    const submittedAt = new Date("2025-01-20T00:00:00.000Z");
+
+    jest.spyOn(DeadlineDb, "findUniqueDeadline").mockResolvedValueOnce({
+      id: 4,
+      name: "Feedback 1",
+      cohortYear: 2025,
+      createdOn: new Date("2025-01-01T00:00:00.000Z"),
+      dueBy: new Date("2025-02-01T00:00:00.000Z"),
+      desc: null,
+      type: "Feedback",
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      evaluatingMilestoneId: null,
+      evaluatorType: "Team",
+    } as any);
+    jest
+      .spyOn(RelationsDb, "findManyRelationsForEvaluations")
+      .mockResolvedValueOnce([]);
+    jest
+      .spyOn(ProjectsDb, "findManyProjectsWithUserData")
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([teamProject] as any);
+    jest
+      .spyOn(SubmissionsDb, "findFirstNonDraftSubmission")
+      .mockResolvedValueOnce({
+        id: 101,
+        deadlineId: 4,
+        fromProjectId: teamProject.id,
+        fromUserId: null,
+        toProjectId: null,
+        toUserId: adviserUser.id,
+        isDraft: false,
+        updatedAt: submittedAt,
+      } as any);
+
+    const result = await getFeedbackSubmissions({
+      cohortYear: 2025,
+      deadlineId: 4,
+      dropped: "false",
+      evaluatorTypeFilter: "Team",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      relationId: `F-A-${teamProject.id}`,
+      fromProject: { id: teamProject.id },
+      toUser: { id: adviserUser.id },
+      submission: {
+        id: 101,
+        deadlineId: 4,
+        isDraft: false,
+        updatedAt: submittedAt,
+      },
+    });
   });
 });

--- a/__tests__/helpers/dashboard.feedback.evaluator.unit.test.ts
+++ b/__tests__/helpers/dashboard.feedback.evaluator.unit.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { AchievementLevel, DeadlineType, EvaluatorType } from "@prisma/client";
+import { getDeadlinesByAdviserId } from "../../src/helpers/dashboard.adviser.helper";
+import { getDeadlinesByStudentId } from "../../src/helpers/dashboard.student.helper";
+import { duplicateDeadlineByDeadlineId } from "../../src/helpers/deadline.helper";
+import * as AdvisersDb from "../../src/models/advisers.db";
+import * as DeadlinesDb from "../../src/models/deadline.db";
+import * as RelationsDb from "../../src/models/relations.db";
+import * as StudentsDb from "../../src/models/students.db";
+import * as SubmissionsDb from "../../src/models/submissions.db";
+
+const adviserUser = {
+  id: 11,
+  name: "Adviser One",
+  email: "adviser@example.com",
+  password: "password",
+};
+
+const project = {
+  id: 21,
+  name: "Project One",
+  teamName: "Team One",
+  cohortYear: 2026,
+  achievement: AchievementLevel.Vostok,
+  adviserId: 31,
+  mentorId: null,
+  proposalPdf: null,
+  posterUrl: null,
+  videoUrl: null,
+  hasDropped: false,
+  adviser: {
+    id: 31,
+    userId: adviserUser.id,
+    cohortYear: 2026,
+    nusnetId: "e0123456",
+    matricNo: "A0123456A",
+    user: adviserUser,
+  },
+};
+
+const buildFeedbackDeadline = (evaluatorType: EvaluatorType | null) => ({
+  id: 41,
+  name: "Feedback One",
+  cohortYear: 2026,
+  createdOn: new Date("2026-01-01T00:00:00.000Z"),
+  dueBy: new Date("2026-02-01T00:00:00.000Z"),
+  desc: null,
+  type: DeadlineType.Feedback,
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  evaluatingMilestoneId: null,
+  evaluating: null,
+  evaluatorType,
+});
+
+const arrangeDashboardData = (evaluatorType: EvaluatorType | null) => {
+  jest
+    .spyOn(StudentsDb, "findUniqueStudentWithProjectWithAdviserUserData")
+    .mockResolvedValue({
+      id: 51,
+      userId: 61,
+      projectId: project.id,
+      cohortYear: 2026,
+      nusnetId: "e0765432",
+      matricNo: "A0765432A",
+      project,
+    } as never);
+  jest.spyOn(AdvisersDb, "findUniqueAdviserWithProjectData").mockResolvedValue({
+    ...project.adviser,
+    projects: [project],
+  } as never);
+  jest
+    .spyOn(DeadlinesDb, "findManyDeadlines")
+    .mockResolvedValue([buildFeedbackDeadline(evaluatorType)]);
+  jest
+    .spyOn(RelationsDb, "findManyRelationsWithFromToProjectData")
+    .mockResolvedValue([]);
+  jest.spyOn(SubmissionsDb, "findFirstSubmission").mockResolvedValue(null);
+  jest
+    .spyOn(SubmissionsDb, "findFirstNonDraftSubmission")
+    .mockResolvedValue(null);
+};
+
+describe("Feedback evaluator task visibility", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows Team feedback only to students", async () => {
+    arrangeDashboardData(EvaluatorType.Team);
+
+    const [studentDeadlines, adviserDeadlines] = await Promise.all([
+      getDeadlinesByStudentId(51),
+      getDeadlinesByAdviserId(31),
+    ]);
+
+    expect(studentDeadlines).toHaveLength(1);
+    expect(adviserDeadlines).toEqual([]);
+  });
+
+  it("shows Adviser feedback only to advisers", async () => {
+    arrangeDashboardData(EvaluatorType.Adviser);
+
+    const [studentDeadlines, adviserDeadlines] = await Promise.all([
+      getDeadlinesByStudentId(51),
+      getDeadlinesByAdviserId(31),
+    ]);
+
+    expect(studentDeadlines).toEqual([]);
+    expect(adviserDeadlines).toHaveLength(1);
+  });
+
+  it("shows Both feedback to students and advisers", async () => {
+    arrangeDashboardData(EvaluatorType.Both);
+
+    const [studentDeadlines, adviserDeadlines] = await Promise.all([
+      getDeadlinesByStudentId(51),
+      getDeadlinesByAdviserId(31),
+    ]);
+
+    expect(studentDeadlines).toHaveLength(1);
+    expect(adviserDeadlines).toHaveLength(1);
+  });
+
+  it("shows Feedback with no evaluator type to both roles", async () => {
+    arrangeDashboardData(null);
+
+    const [studentDeadlines, adviserDeadlines] = await Promise.all([
+      getDeadlinesByStudentId(51),
+      getDeadlinesByAdviserId(31),
+    ]);
+
+    expect(studentDeadlines).toHaveLength(1);
+    expect(adviserDeadlines).toHaveLength(1);
+  });
+});
+
+describe("Feedback evaluator metadata", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("preserves evaluator type when duplicating a Feedback deadline", async () => {
+    const feedbackDeadline = buildFeedbackDeadline(EvaluatorType.Team);
+    jest
+      .spyOn(DeadlinesDb, "findUniqueDeadline")
+      .mockResolvedValue(feedbackDeadline);
+    const createDeadlineSpy = jest
+      .spyOn(DeadlinesDb, "createOneDeadline")
+      .mockResolvedValue({
+        ...feedbackDeadline,
+        id: 42,
+        name: `Copy of ${feedbackDeadline.name}`,
+      });
+
+    await duplicateDeadlineByDeadlineId(feedbackDeadline.id, 2027);
+
+    expect(createDeadlineSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: DeadlineType.Feedback,
+          evaluatorType: EvaluatorType.Team,
+        }),
+      })
+    );
+  });
+});

--- a/__tests__/routes/dashboard.admin.unit.test.ts
+++ b/__tests__/routes/dashboard.admin.unit.test.ts
@@ -340,3 +340,41 @@ describe("GET /team-submissions route unit test", () => {
     assertApiResponse({ submissions: [MOCK_PROJECT_WITHOUT_SUBMISSION] });
   });
 });
+
+describe("GET /feedback route unit test", () => {
+  let getFeedbackSubmissions;
+
+  beforeAll(() => {
+    getFeedbackSubmissions = jest.spyOn(
+      DashboardAdminHelpers,
+      "getFeedbackSubmissions"
+    );
+  });
+
+  it("should call the helper function correctly to get feedback submissions", async () => {
+    const deadlineId = 4;
+    getFeedbackSubmissions.mockResolvedValueOnce([
+      MOCK_PROJECT_WITH_SUBMISSION,
+      MOCK_PROJECT_WITHOUT_SUBMISSION,
+    ]);
+
+    await supertest(app).get(
+      `${BASE_URL}/feedback?cohortYear=${MOCK_SUBMISSION.cohortYear}&dropped=${MOCK_SUBMISSION.dropped}&deadlineId=${deadlineId}`
+    );
+
+    expect(authorizeAdmin).toHaveBeenCalledTimes(1);
+    expect(getFeedbackSubmissions).toHaveBeenCalledTimes(1);
+    expect(getFeedbackSubmissions).toHaveBeenCalledWith({
+      cohortYear: MOCK_SUBMISSION.cohortYear,
+      dropped: MOCK_SUBMISSION.dropped,
+      deadlineId,
+    });
+
+    assertApiResponse({
+      submissions: [
+        MOCK_PROJECT_WITH_SUBMISSION,
+        MOCK_PROJECT_WITHOUT_SUBMISSION,
+      ],
+    });
+  });
+});

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   Adviser,
+  DeadlineType,
+  EvaluatorType,
   Mentor,
   Project,
   Student,
@@ -106,6 +108,16 @@ const withoutPassword = (user?: User | null) => {
   return removePasswordFromUser(user);
 };
 
+const includesTeamEvaluator = (evaluatorType: EvaluatorType | null) =>
+  !evaluatorType ||
+  evaluatorType === EvaluatorType.Team ||
+  evaluatorType === EvaluatorType.Both;
+
+const includesAdviserEvaluator = (evaluatorType: EvaluatorType | null) =>
+  !evaluatorType ||
+  evaluatorType === EvaluatorType.Adviser ||
+  evaluatorType === EvaluatorType.Both;
+
 const flattenStudentUser = (student: Student & { user?: User | null }) => {
   const { user, id: studentId, ...studentData } = student;
   return {
@@ -191,6 +203,7 @@ export const getSubmissions = async (
   query: any & {
     cohortYear: number;
     deadlineId?: number;
+    deadlineType?: DeadlineType;
     submissionStatus?: SubmissionStatusEnum;
     search?: string;
     page?: number;
@@ -204,6 +217,27 @@ export const getSubmissions = async (
   }
 
   return await getAllSubmissions(query);
+};
+
+export const getFeedbackSubmissions = async (
+  query: any & {
+    cohortYear: number;
+    deadlineId?: number;
+    submissionStatus?: SubmissionStatusEnum;
+    search?: string;
+    page?: number;
+    limit?: number;
+    dropped: boolean;
+  }
+) => {
+  const feedbackQuery = {
+    ...query,
+    deadlineType: DeadlineType.Feedback,
+  };
+
+  return query.deadlineId
+    ? await getEvaluationSubmissionsByDeadlineId(feedbackQuery)
+    : await getAllEvaluationSubmissions(feedbackQuery);
 };
 
 export const getCollatedMilestoneSubmissions = async (
@@ -477,11 +511,7 @@ export const getCollatedMilestoneSubmissions = async (
         answers: { questionId: number; answer: string }[];
       }[] = [];
 
-      if (
-        !deadline.evaluatorType ||
-        deadline.evaluatorType === "Team" ||
-        deadline.evaluatorType === "Both"
-      ) {
+      if (includesTeamEvaluator(deadline.evaluatorType)) {
         teamRelations.forEach((relation) => {
           const submission = evaluationSubmissionsMap.get(
             `team-${deadline.id}-${relation.fromProjectId}-${relation.toProjectId}`
@@ -501,10 +531,7 @@ export const getCollatedMilestoneSubmissions = async (
         });
       }
 
-      if (
-        deadline.evaluatorType === "Adviser" ||
-        deadline.evaluatorType === "Both"
-      ) {
+      if (includesAdviserEvaluator(deadline.evaluatorType)) {
         adviserProjects.forEach((project) => {
           if (!project.adviser?.userId) return;
           const submission = evaluationSubmissionsMap.get(
@@ -585,6 +612,7 @@ export const getCollatedMilestoneSubmissions = async (
 export const getAllSubmissions = async (
   query: any & {
     cohortYear: number;
+    deadlineType?: DeadlineType;
     search?: string;
     page?: number;
     limit?: number;
@@ -592,6 +620,7 @@ export const getAllSubmissions = async (
   }
 ) => {
   const { search, cohortYear, page, limit, dropped } = query;
+  const deadlineType = query.deadlineType ?? DeadlineType.Milestone;
   const isDropped = dropped === "true" || dropped === true;
 
   const searchCondition = search
@@ -613,10 +642,10 @@ export const getAllSubmissions = async (
     skip: query.limit && query.page ? limit * page : undefined,
   });
 
-  const milestoneDeadlines = await findManyDeadlines({
+  const deadlines = await findManyDeadlines({
     where: {
       cohortYear: Number(cohortYear),
-      type: "Milestone",
+      type: deadlineType,
     },
   });
 
@@ -626,9 +655,7 @@ export const getAllSubmissions = async (
         fromProjectId: project.id,
         isDraft: false,
         deadlineId: {
-          in: milestoneDeadlines.map(
-            (milestoneDeadline) => milestoneDeadline.id
-          ),
+          in: deadlines.map((deadline) => deadline.id),
         },
       },
       select: {
@@ -710,7 +737,7 @@ export const getSubmissionsByDeadlineId = async (
         where: {
           deadlineId: deadlineId,
           fromProjectId: project.id,
-          toUserId: project.adviserId,
+          toUserId: project.adviser?.userId,
         },
       });
       return {
@@ -807,6 +834,10 @@ export const getAllEvaluationSubmissions = async (query: any) => {
   const { search, cohortYear, page, limit, dropped, evaluatorTypeFilter } =
     query;
   const isDropped = dropped === "true" || dropped === true;
+  const deadlineType = query.deadlineType ?? DeadlineType.Evaluation;
+  const isFeedback = deadlineType === DeadlineType.Feedback;
+  const includeAnswers =
+    query.includeAnswers === "true" || query.includeAnswers === true;
 
   const teamSearchCondition = search
     ? {
@@ -851,27 +882,50 @@ export const getAllEvaluationSubmissions = async (query: any) => {
     : {};
 
   const evaluationDeadlines = await findManyDeadlines({
-    where: { cohortYear: Number(cohortYear), type: "Evaluation" },
+    where: { cohortYear: Number(cohortYear), type: deadlineType },
   });
   const deadlineIds = evaluationDeadlines.map((d) => d.id);
+  const hasTeamDeadline = evaluationDeadlines.some((deadline) =>
+    includesTeamEvaluator(deadline.evaluatorType)
+  );
+  const hasAdviserDeadline = evaluationDeadlines.some((deadline) =>
+    includesAdviserEvaluator(deadline.evaluatorType)
+  );
 
   let combined: any[] = [];
 
   // Fetch Teams if filter allows
   if (
-    !evaluatorTypeFilter ||
-    evaluatorTypeFilter === "All" ||
-    evaluatorTypeFilter === "Team"
+    hasTeamDeadline &&
+    (!evaluatorTypeFilter ||
+      evaluatorTypeFilter === "All" ||
+      evaluatorTypeFilter === "Team")
   ) {
     const relations = await findManyRelationsForEvaluations({
       where: {
-        fromProject: { cohortYear: Number(cohortYear), hasDropped: isDropped },
+        ...(isFeedback
+          ? {
+              toProject: {
+                cohortYear: Number(cohortYear),
+                hasDropped: isDropped,
+              },
+            }
+          : {
+              fromProject: {
+                cohortYear: Number(cohortYear),
+                hasDropped: isDropped,
+              },
+            }),
         ...teamSearchCondition,
       },
     });
 
     const evaluatorProjectIds = Array.from(
-      new Set(relations.map((r) => r.fromProjectId))
+      new Set(
+        relations.map((relation) =>
+          isFeedback ? relation.toProjectId : relation.fromProjectId
+        )
+      )
     );
     const evaluatorProjects = await findManyProjectsWithUserData({
       where: { id: { in: evaluatorProjectIds } },
@@ -881,42 +935,88 @@ export const getAllEvaluationSubmissions = async (query: any) => {
     );
 
     const pTeamSubmissions = relations.map(async (relation) => {
+      const evaluatorProject = isFeedback
+        ? relation.toProject
+        : relation.fromProject;
+      const evaluateeProject = isFeedback
+        ? relation.fromProject
+        : relation.toProject;
       const submissions = await findManySubmissions({
         where: {
-          fromProjectId: relation.fromProjectId,
-          toProjectId: relation.toProjectId,
+          fromProjectId: evaluatorProject.id,
+          toProjectId: evaluateeProject.id,
           isDraft: false,
           deadlineId: { in: deadlineIds },
         },
-        select: { id: true, updatedAt: true, deadlineId: true },
+        ...(includeAnswers
+          ? { include: { answers: { include: { question: true } } } }
+          : { select: { id: true, updatedAt: true, deadlineId: true } }),
       });
 
       const rawStudents =
-        projectsWithStudentsMap.get(relation.fromProjectId) || [];
+        projectsWithStudentsMap.get(evaluatorProject.id) || [];
       const flattenedStudents = rawStudents.map((student) =>
         flattenStudentUser(student)
       );
 
       return {
-        relationId: relation.id,
+        relationId: isFeedback ? `F-T-${relation.id}` : relation.id,
         fromProject: {
-          ...relation.fromProject,
-          adviser: relation.fromProject.adviser
-            ? flattenAdviserUser(relation.fromProject.adviser)
+          ...evaluatorProject,
+          adviser: evaluatorProject.adviser
+            ? flattenAdviserUser(evaluatorProject.adviser)
             : null,
           students: flattenedStudents,
         },
-        toProject: flattenProjectUsers(relation.toProject),
+        toProject: flattenProjectUsers(evaluateeProject),
         submission: submissions.length > 0 ? submissions : undefined,
       };
     });
     combined.push(...(await Promise.all(pTeamSubmissions)));
+
+    if (isFeedback) {
+      const teamAdviserProjects = await findManyProjectsWithUserData({
+        where: {
+          cohortYear: Number(cohortYear),
+          hasDropped: isDropped,
+          adviserId: { not: null },
+          ...adviserSearchCondition,
+        },
+      });
+      const teamAdviserSubmissions = teamAdviserProjects.map(
+        async (project) => {
+          if (!project.adviser) return null;
+          const submissions = await findManySubmissions({
+            where: {
+              fromProjectId: project.id,
+              toUserId: project.adviser.userId,
+              isDraft: false,
+              deadlineId: { in: deadlineIds },
+            },
+            ...(includeAnswers
+              ? { include: { answers: { include: { question: true } } } }
+              : { select: { id: true, updatedAt: true, deadlineId: true } }),
+          });
+          return {
+            relationId: `F-A-${project.id}`,
+            fromProject: flattenProjectUsers(project),
+            fromUser: undefined,
+            toUser: withoutPassword(project.adviser.user),
+            submission: submissions.length > 0 ? submissions : undefined,
+          };
+        }
+      );
+      combined.push(
+        ...(await Promise.all(teamAdviserSubmissions)).filter(Boolean)
+      );
+    }
   }
 
   if (
-    !evaluatorTypeFilter ||
-    evaluatorTypeFilter === "All" ||
-    evaluatorTypeFilter === "Adviser"
+    hasAdviserDeadline &&
+    (!evaluatorTypeFilter ||
+      evaluatorTypeFilter === "All" ||
+      evaluatorTypeFilter === "Adviser")
   ) {
     const adviserProjects = await findManyProjectsWithUserData({
       where: {
@@ -935,7 +1035,9 @@ export const getAllEvaluationSubmissions = async (query: any) => {
           isDraft: false,
           deadlineId: { in: deadlineIds },
         },
-        select: { id: true, updatedAt: true, deadlineId: true },
+        ...(includeAnswers
+          ? { include: { answers: { include: { question: true } } } }
+          : { select: { id: true, updatedAt: true, deadlineId: true } }),
       });
       return {
         relationId: `A-${project.id}`,
@@ -993,17 +1095,34 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
     evaluatorTypeFilter,
   } = query;
   const isDropped = dropped === "true" || dropped === true;
+  const deadlineType = query.deadlineType ?? DeadlineType.Evaluation;
+  const isFeedback = deadlineType === DeadlineType.Feedback;
+  const includeAnswers =
+    query.includeAnswers === "true" || query.includeAnswers === true;
 
   const deadline = await findUniqueDeadline({
     where: { id: Number(deadlineId) },
   });
 
   let results: any[] = [];
+  const adviserSearchCondition = search
+    ? {
+        OR: [
+          {
+            adviser: {
+              user: {
+                name: { contains: search, mode: "insensitive" as const },
+              },
+            },
+          },
+          { name: { contains: search, mode: "insensitive" as const } },
+          { teamName: { contains: search, mode: "insensitive" as const } },
+        ],
+      }
+    : {};
 
   const includeTeams =
-    (!deadline.evaluatorType ||
-      deadline.evaluatorType === "Team" ||
-      deadline.evaluatorType === "Both") &&
+    includesTeamEvaluator(deadline.evaluatorType) &&
     (!evaluatorTypeFilter ||
       evaluatorTypeFilter === "All" ||
       evaluatorTypeFilter === "Team");
@@ -1037,13 +1156,29 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
       : {};
     const relations = await findManyRelationsForEvaluations({
       where: {
-        fromProject: { cohortYear: Number(cohortYear), hasDropped: isDropped },
+        ...(isFeedback
+          ? {
+              toProject: {
+                cohortYear: Number(cohortYear),
+                hasDropped: isDropped,
+              },
+            }
+          : {
+              fromProject: {
+                cohortYear: Number(cohortYear),
+                hasDropped: isDropped,
+              },
+            }),
         ...teamSearchCondition,
       },
     });
 
     const evaluatorProjectIds = Array.from(
-      new Set(relations.map((r) => r.fromProjectId))
+      new Set(
+        relations.map((relation) =>
+          isFeedback ? relation.toProjectId : relation.fromProjectId
+        )
+      )
     );
     const evaluatorProjects = await findManyProjectsWithUserData({
       where: { id: { in: evaluatorProjectIds } },
@@ -1053,60 +1188,88 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
     );
 
     const pTeamSubmissions = relations.map(async (relation) => {
+      const evaluatorProject = isFeedback
+        ? relation.toProject
+        : relation.fromProject;
+      const evaluateeProject = isFeedback
+        ? relation.fromProject
+        : relation.toProject;
       const submission = await findFirstNonDraftSubmission({
         where: {
           deadlineId: Number(deadlineId),
-          fromProjectId: relation.fromProjectId,
-          toProjectId: relation.toProjectId,
+          fromProjectId: evaluatorProject.id,
+          toProjectId: evaluateeProject.id,
         },
+        include: includeAnswers
+          ? { answers: { include: { question: true } } }
+          : undefined,
       });
 
       const rawStudents =
-        projectsWithStudentsMap.get(relation.fromProjectId) || [];
+        projectsWithStudentsMap.get(evaluatorProject.id) || [];
       const flattenedStudents = rawStudents.map((student) =>
         flattenStudentUser(student)
       );
 
-      const adviser = relation.fromProject.adviser;
+      const adviser = evaluatorProject.adviser;
       const sanitizedAdviser = adviser ? flattenAdviserUser(adviser) : null;
 
       return {
-        relationId: relation.id,
+        relationId: isFeedback ? `F-T-${relation.id}` : relation.id,
         fromProject: {
-          ...relation.fromProject,
+          ...evaluatorProject,
           adviser: sanitizedAdviser,
           students: flattenedStudents,
         },
-        toProject: flattenProjectUsers(relation.toProject),
+        toProject: flattenProjectUsers(evaluateeProject),
         submission: submission || undefined,
       };
     });
     results.push(...(await Promise.all(pTeamSubmissions)));
+
+    if (isFeedback) {
+      const teamAdviserProjects = await findManyProjectsWithUserData({
+        where: {
+          cohortYear: Number(cohortYear),
+          hasDropped: isDropped,
+          adviserId: { not: null },
+          ...adviserSearchCondition,
+        },
+      });
+      const teamAdviserSubmissions = teamAdviserProjects.map(
+        async (project) => {
+          if (!project.adviser) return null;
+          const submission = await findFirstNonDraftSubmission({
+            where: {
+              deadlineId: Number(deadlineId),
+              fromProjectId: project.id,
+              toUserId: project.adviser.userId,
+            },
+            include: includeAnswers
+              ? { answers: { include: { question: true } } }
+              : undefined,
+          });
+          return {
+            relationId: `F-A-${project.id}`,
+            fromProject: flattenProjectUsers(project),
+            toUser: withoutPassword(project.adviser.user),
+            submission: submission || undefined,
+          };
+        }
+      );
+      results.push(
+        ...(await Promise.all(teamAdviserSubmissions)).filter(Boolean)
+      );
+    }
   }
 
   const includeAdvisers =
-    (deadline.evaluatorType === "Adviser" ||
-      deadline.evaluatorType === "Both") &&
+    includesAdviserEvaluator(deadline.evaluatorType) &&
     (!evaluatorTypeFilter ||
       evaluatorTypeFilter === "All" ||
       evaluatorTypeFilter === "Adviser");
 
   if (includeAdvisers) {
-    const adviserSearchCondition = search
-      ? {
-          OR: [
-            {
-              adviser: {
-                user: {
-                  name: { contains: search, mode: "insensitive" as const },
-                },
-              },
-            },
-            { name: { contains: search, mode: "insensitive" as const } },
-            { teamName: { contains: search, mode: "insensitive" as const } },
-          ],
-        }
-      : {};
     const adviserProjects = await findManyProjectsWithUserData({
       where: {
         cohortYear: Number(cohortYear),
@@ -1129,6 +1292,9 @@ export const getEvaluationSubmissionsByDeadlineId = async (query: any) => {
           fromUserId: adviser.userId,
           toProjectId: project.id,
         },
+        include: includeAnswers
+          ? { answers: { include: { question: true } } }
+          : undefined,
       });
 
       const adviserUser: any = adviser.user;

--- a/src/helpers/dashboard.admin.helper.ts
+++ b/src/helpers/dashboard.admin.helper.ts
@@ -708,7 +708,7 @@ export const getSubmissionsByDeadlineId = async (
 
   let results: {
     fromProject: Project;
-    toUser?: User;
+    toUser?: Omit<User, "password">;
     toProject?: Project;
     submission?: Submission;
   }[];
@@ -733,20 +733,24 @@ export const getSubmissionsByDeadlineId = async (
     results = await Promise.all(pSubmissions);
   } else if (deadline.type == "Feedback") {
     const pSubmissions = projects.map(async (project) => {
+      if (!project.adviser) return null;
+
       const submission = await findFirstNonDraftSubmission({
         where: {
           deadlineId: deadlineId,
           fromProjectId: project.id,
-          toUserId: project.adviser?.userId,
+          toUserId: project.adviser.userId,
         },
       });
       return {
         fromProject: flattenProjectUsers(project),
-        toUser: project.adviser?.user,
+        toUser: removePasswordFromUser(project.adviser.user),
         submission: submission || undefined,
       };
     });
-    results = await Promise.all(pSubmissions);
+    results = (await Promise.all(pSubmissions)).filter(
+      (result): result is NonNullable<typeof result> => result !== null
+    );
   } else {
     const pSubmissions = projects.map(async (project) => {
       const submission = await findFirstNonDraftSubmission({

--- a/src/helpers/dashboard.adviser.helper.ts
+++ b/src/helpers/dashboard.adviser.helper.ts
@@ -1,4 +1,4 @@
-import { DeadlineType, Prisma } from "@prisma/client";
+import { DeadlineType, EvaluatorType, Prisma } from "@prisma/client";
 import { SkylabError } from "../errors/SkylabError";
 import { findUniqueAdviserWithProjectData } from "../models/advisers.db";
 import { findManyDeadlines } from "../models/deadline.db";
@@ -8,6 +8,16 @@ import {
   findManySubmissions,
 } from "../models/submissions.db";
 import { HttpStatusCode } from "../utils/HTTP_Status_Codes";
+
+const canAdviserSubmit = (evaluatorType: EvaluatorType | null) =>
+  !evaluatorType ||
+  evaluatorType === EvaluatorType.Adviser ||
+  evaluatorType === EvaluatorType.Both;
+
+const canTeamSubmit = (evaluatorType: EvaluatorType | null) =>
+  !evaluatorType ||
+  evaluatorType === EvaluatorType.Team ||
+  evaluatorType === EvaluatorType.Both;
 
 export async function getDeadlinesByAdviserId(adviserId: number) {
   const adviser = await findUniqueAdviserWithProjectData({
@@ -39,7 +49,7 @@ export async function getDeadlinesByAdviserId(adviserId: number) {
         );
       }
 
-      if (deadline.evaluatorType === "Team") {
+      if (!canAdviserSubmit(deadline.evaluatorType)) {
         return [];
       }
 
@@ -76,6 +86,10 @@ export async function getDeadlinesByAdviserId(adviserId: number) {
         })
       );
     } else {
+      if (!canAdviserSubmit(deadline.evaluatorType)) {
+        return [];
+      }
+
       return await Promise.all(
         projects.map(async (project) => {
           const { id: toProjectId } = project;
@@ -134,7 +148,7 @@ export async function getProjectSubmissionsViaAdviserId(adviserId: number) {
         submissions: await Promise.all(milestoneSubmissions),
       };
     } else if (deadline.type == "Evaluation") {
-      if (deadline.evaluatorType === "Adviser") {
+      if (!canTeamSubmit(deadline.evaluatorType)) {
         return {
           deadline: deadline,
           submissions: [],
@@ -157,6 +171,13 @@ export async function getProjectSubmissionsViaAdviserId(adviserId: number) {
         submissions: evaluationSubmissions,
       };
     } else if (deadline.type == "Feedback") {
+      if (!canTeamSubmit(deadline.evaluatorType)) {
+        return {
+          deadline: deadline,
+          submissions: [],
+        };
+      }
+
       const feedbackSubmissions = adviser.projects.map(async (project) => {
         const submission = await findFirstNonDraftSubmission({
           where: {

--- a/src/helpers/dashboard.student.helper.ts
+++ b/src/helpers/dashboard.student.helper.ts
@@ -1,4 +1,9 @@
-import { DeadlineType, Prisma, Submission } from "@prisma/client";
+import {
+  DeadlineType,
+  EvaluatorType,
+  Prisma,
+  Submission,
+} from "@prisma/client";
 import { SkylabError } from "../errors/SkylabError";
 import { findManyDeadlines, findManyEvaluations } from "../models/deadline.db";
 import { findManyRelationsWithFromToProjectData } from "../models/relations.db";
@@ -13,6 +18,16 @@ import {
 } from "../models/submissions.db";
 import { findUniqueUser } from "../models/users.db";
 import { HttpStatusCode } from "../utils/HTTP_Status_Codes";
+
+const canTeamSubmit = (evaluatorType: EvaluatorType | null) =>
+  !evaluatorType ||
+  evaluatorType === EvaluatorType.Team ||
+  evaluatorType === EvaluatorType.Both;
+
+const canAdviserSubmit = (evaluatorType: EvaluatorType | null) =>
+  !evaluatorType ||
+  evaluatorType === EvaluatorType.Adviser ||
+  evaluatorType === EvaluatorType.Both;
 
 export async function getDeadlinesByStudentId(studentId: number) {
   const student = await findUniqueStudentWithProjectWithAdviserUserData({
@@ -73,7 +88,7 @@ export async function getDeadlinesByStudentId(studentId: number) {
         submission: submission ? submission : undefined,
       };
     } else if (deadline.type == "Evaluation") {
-      if (deadline.evaluatorType === "Adviser") {
+      if (!canTeamSubmit(deadline.evaluatorType)) {
         return [];
       }
       const pEvaluationDeadlines = relations.map(async (relation) => {
@@ -108,6 +123,10 @@ export async function getDeadlinesByStudentId(studentId: number) {
       });
       return await Promise.all(pEvaluationDeadlines);
     } else {
+      if (!canTeamSubmit(deadline.evaluatorType)) {
+        return [];
+      }
+
       const submission = await findFirstSubmission({
         where: {
           deadlineId: deadline.id,
@@ -200,7 +219,7 @@ export async function getPeerEvaluationFeedbackByStudentID(studentId: number) {
 
       let peerSubmissions: PeerFeedback[] = [];
 
-      if (deadline.evaluatorType !== "Adviser") {
+      if (canTeamSubmit(deadline.evaluatorType)) {
         // Query submissions directly — survives EvaluationRelation deletion.
         peerSubmissions = (await findManySubmissions({
           where: {
@@ -222,7 +241,7 @@ export async function getPeerEvaluationFeedbackByStudentID(studentId: number) {
 
       let adviserSubmissionWrapper: AdviserFeedback | null = null;
 
-      if (deadline.evaluatorType !== "Team") {
+      if (canAdviserSubmit(deadline.evaluatorType)) {
         const pAdviserSubmission = await findFirstNonDraftSubmission({
           where: {
             deadlineId: deadline.id,

--- a/src/helpers/deadline.helper.ts
+++ b/src/helpers/deadline.helper.ts
@@ -54,7 +54,7 @@ export async function createDeadline(body: {
     type: DeadlineType;
     desc?: string;
     evaluatingMilestoneId?: number; // If type == "Evaluation"
-    evaluatorType?: EvaluatorType; // If type == "Evaluation"
+    evaluatorType?: EvaluatorType; // If type == "Evaluation" or "Feedback"
   };
 }) {
   const { deadline: deadlineData } = body;
@@ -66,7 +66,10 @@ export async function createDeadline(body: {
       cohort: { connect: { academicYear: cohortYear } },
       ...deadline,
       evaluatorType:
-        deadline.type === DeadlineType.Evaluation ? evaluatorType : undefined,
+        deadline.type === DeadlineType.Evaluation ||
+        deadline.type === DeadlineType.Feedback
+          ? evaluatorType
+          : undefined,
       evaluating:
         deadline.type === DeadlineType.Evaluation
           ? {
@@ -285,11 +288,13 @@ export async function editDeadlineByDeadlineId(
 ) {
   const { evaluatingMilestoneId, ...deadline } = body.deadline;
   const isEvaluationDeadline = deadline.type === DeadlineType.Evaluation;
+  const supportsEvaluatorType =
+    isEvaluationDeadline || deadline.type === DeadlineType.Feedback;
   const updatedDeadline = await updateOneDeadline({
     where: { id: deadlineId },
     data: {
       ...deadline,
-      evaluatorType: isEvaluationDeadline ? deadline.evaluatorType : null,
+      evaluatorType: supportsEvaluatorType ? deadline.evaluatorType : null,
       evaluating: isEvaluationDeadline
         ? evaluatingMilestoneId
           ? { connect: { id: evaluatingMilestoneId } }
@@ -314,7 +319,8 @@ export async function duplicateDeadlineByDeadlineId(
 ) {
   const deadline = await getOneDeadlineById(deadlineId);
   if (!deadline) return null;
-  const { name, dueBy, type, desc, evaluatingMilestoneId } = deadline;
+  const { name, dueBy, type, desc, evaluatingMilestoneId, evaluatorType } =
+    deadline;
   const duplicatedDeadline = await createDeadline({
     deadline: {
       cohortYear,
@@ -323,6 +329,7 @@ export async function duplicateDeadlineByDeadlineId(
       type,
       desc: desc as string | undefined,
       evaluatingMilestoneId: evaluatingMilestoneId as number | undefined,
+      evaluatorType: evaluatorType as EvaluatorType | undefined,
     },
   });
   return duplicatedDeadline;

--- a/src/routes/dashboard.admin.ts
+++ b/src/routes/dashboard.admin.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import { validationResult } from "express-validator";
 import {
   getSubmissions,
+  getFeedbackSubmissions,
   getEvaluationSubmissions,
   getCollatedMilestoneSubmissions,
   sendReminderEmail,
@@ -46,6 +47,24 @@ router.get(
     }
     try {
       const submissions = await getSubmissions(req.query);
+      return apiResponseWrapper(res, { submissions: submissions });
+    } catch (e) {
+      return routeErrorHandler(res, e);
+    }
+  }
+);
+
+router.get(
+  "/feedback",
+  authorizeAdmin,
+  GetSubmissionsByDeadlineIDValidator,
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req).formatWith(errorFormatter);
+    if (!errors.isEmpty()) {
+      return throwValidationError(res, errors);
+    }
+    try {
+      const submissions = await getFeedbackSubmissions(req.query);
       return apiResponseWrapper(res, { submissions: submissions });
     } catch (e) {
       return routeErrorHandler(res, e);

--- a/src/validators/dashboard.admin.validator.ts
+++ b/src/validators/dashboard.admin.validator.ts
@@ -6,6 +6,7 @@ export const GetSubmissionsByDeadlineIDValidator = [
   CohortQueryValidator,
   query("deadlineId").isNumeric().toInt().optional(),
   query("includeAnonymous").isBoolean().optional(),
+  query("includeAnswers").isBoolean().optional(),
   query("submissionStatus")
     .isIn([
       SubmissionStatusEnum.SUBMITTED,

--- a/src/validators/deadline.validator.ts
+++ b/src/validators/deadline.validator.ts
@@ -39,7 +39,11 @@ export const CreateDeadlineValidator = [
       }
     }),
   body("deadline.evaluatorType")
-    .if(body("deadline.type").equals("Evaluation"))
+    .if((value, { req }) =>
+      [DeadlineType.Evaluation, DeadlineType.Feedback].includes(
+        req.body.deadline?.type
+      )
+    )
     .notEmpty()
     .isIn(Object.values(EvaluatorType)),
 ];


### PR DESCRIPTION
## Summary

- Support Team, Adviser, and Both evaluator types for Feedback deadlines.
- Apply evaluator visibility rules to student and adviser dashboards.
- Add the administrator Feedback endpoint with filtering, pagination, reminders, and CSV answer data.
- Treat existing deadlines without an evaluator type as Both.

## Testing

- Added evaluator visibility and deadline duplication tests.
- Added admin Feedback helper and route tests.